### PR TITLE
Align CoreModels duration formatting with iOS output

### DIFF
--- a/Packages/CoreModels/Sources/CoreModels/EpisodeFilterService.swift
+++ b/Packages/CoreModels/Sources/CoreModels/EpisodeFilterService.swift
@@ -685,10 +685,7 @@ public actor DefaultEpisodeFilterService: EpisodeFilterService { // swiftlint:di
     
     /// Format duration for search
     nonisolated private func formatDuration(_ duration: TimeInterval) -> String {
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.hour, .minute, .second]
-        formatter.unitsStyle = .abbreviated
-        return formatter.string(from: duration) ?? ""
+        duration.abbreviatedDescription(includeSeconds: true)
     }
 }
 

--- a/Packages/CoreModels/Sources/CoreModels/SmartEpisodeListRules.swift
+++ b/Packages/CoreModels/Sources/CoreModels/SmartEpisodeListRules.swift
@@ -245,10 +245,7 @@ public enum SmartListRuleValue: Codable, Equatable, Sendable {
     }
     
     private func formatDuration(_ duration: TimeInterval) -> String {
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.hour, .minute]
-        formatter.unitsStyle = .abbreviated
-        return formatter.string(from: duration) ?? "\(Int(duration))s"
+        duration.abbreviatedDescription(includeSeconds: false)
     }
 }
 

--- a/Packages/CoreModels/Sources/CoreModels/TimeInterval+Formatting.swift
+++ b/Packages/CoreModels/Sources/CoreModels/TimeInterval+Formatting.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Utilities for producing abbreviated, human-readable duration strings that work across platforms.
+extension TimeInterval {
+    /// Returns a string such as "1h 2m 3s" (when `includeSeconds` is true) or "1h 2m" for positive durations.
+    /// - Parameter includeSeconds: When true, seconds are included; otherwise only hours and minutes are shown.
+    /// - Returns: An abbreviated duration string appropriate for search facets and smart list displays.
+    func abbreviatedDescription(includeSeconds: Bool) -> String {
+        guard isFinite else { return includeSeconds ? "0s" : "0m" }
+
+        let clampedDuration = max(0, self)
+        let totalSeconds = Int(clampedDuration)
+
+        let hours = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
+        let seconds = totalSeconds % 60
+
+        var components: [String] = []
+
+        if hours > 0 {
+            components.append("\(hours)h")
+        }
+
+        if minutes > 0 || (hours == 0 && !includeSeconds) {
+            components.append("\(minutes)m")
+        }
+
+        if includeSeconds && (seconds > 0 || components.isEmpty) {
+            components.append("\(seconds)s")
+        }
+
+        if components.isEmpty {
+            return includeSeconds ? "0s" : "0m"
+        }
+
+        return components.joined(separator: " ")
+    }
+}

--- a/Packages/CoreModels/Tests/CoreModelsTests/TimeIntervalFormattingTests.swift
+++ b/Packages/CoreModels/Tests/CoreModelsTests/TimeIntervalFormattingTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import CoreModels
+
+final class TimeIntervalFormattingTests: XCTestCase {
+    func testAbbreviatedDescription_withSecondsDropsZeroMinutes() {
+        XCTAssertEqual(TimeInterval(3_600).abbreviatedDescription(includeSeconds: true), "1h")
+    }
+
+    func testAbbreviatedDescription_withSecondsIncludesHoursMinutesSeconds() {
+        XCTAssertEqual(TimeInterval(3_661).abbreviatedDescription(includeSeconds: true), "1h 1m 1s")
+    }
+
+    func testAbbreviatedDescription_withSecondsHandlesSubMinuteDurations() {
+        XCTAssertEqual(TimeInterval(59).abbreviatedDescription(includeSeconds: true), "59s")
+    }
+
+    func testAbbreviatedDescription_withoutSecondsUsesMinutes() {
+        XCTAssertEqual(TimeInterval(3_661).abbreviatedDescription(includeSeconds: false), "1h 1m")
+    }
+
+    func testAbbreviatedDescription_withoutSecondsClampsToMinutes() {
+        XCTAssertEqual(TimeInterval(45).abbreviatedDescription(includeSeconds: false), "0m")
+    }
+
+    func testAbbreviatedDescription_ignoresFractionalSeconds() {
+        XCTAssertEqual(TimeInterval(3599.9).abbreviatedDescription(includeSeconds: true), "59m 59s")
+    }
+
+    func testAbbreviatedDescription_handlesNegativeOrInfinite() {
+        XCTAssertEqual(TimeInterval(-120).abbreviatedDescription(includeSeconds: true), "0s")
+        XCTAssertEqual(Double.infinity.abbreviatedDescription(includeSeconds: false), "0m")
+    }
+}

--- a/dev-log/02.2.2-episode-list-viewmodel-modularization.md
+++ b/dev-log/02.2.2-episode-list-viewmodel-modularization.md
@@ -1,0 +1,25 @@
+# Dev Log: Issue 02.2.2 - EpisodeListViewModel Modularization
+
+## Date: 2025-10-29
+
+## Context
+Preflight compilation failed on Linux after the last refactor because new helpers inside `CoreModels` relied on `DateComponentsFormatter`, which is unavailable in swift-corelibs-foundation. The failure blocked `swift build` during the preflight stage.
+
+## Investigation Notes
+- Reproduced the failure locally with `swift build` and confirmed the compiler errors in `EpisodeFilterService.formatDuration` and `SmartEpisodeListRules.formatDuration`.
+- Verified no other files referenced `DateComponentsFormatter` inside `CoreModels`, so the regression was limited to the reusable filtering utilities.
+
+## Fix
+- Added a cross-platform `TimeInterval.abbreviatedDescription(includeSeconds:)` helper in `CoreModels` to replace the Foundation formatter while preserving abbreviated output.
+- Updated the filtering and smart list formatting helpers to call the new extension so both search snippets and smart-list summaries share the same implementation.
+- Re-ran `swift build`; the run now progresses past CoreModels (confirming the formatter fix) and only fails once it reaches SwiftUI packages, which is expected in the Linux environment.
+
+## Date: 2025-10-30
+
+## Follow-up Validation
+- Added unit coverage in `TimeIntervalFormattingTests` to lock in the abbreviated output rules, especially around edge cases like zero durations, fractional seconds, and hours-only values.
+- Tweaked the helper to floor fractional seconds and skip zero-minute components when seconds are shown so the behavior matches the former `DateComponentsFormatter` results (e.g., "1h" instead of "1h 0m").
+- Re-ran the CoreModels test suite to verify the helper produces the expected strings on Linux.
+
+## Next Steps
+- Monitor downstream UI formatting to make sure the abbreviated output continues to meet the acceptance criteria; adjust thresholds if tests flag regressions.


### PR DESCRIPTION
## Summary
- floor fractional durations and avoid zero-minute fragments when seconds are shown so the Linux-safe formatter matches prior DateComponentsFormatter behavior
- add CoreModels unit tests that lock in the abbreviated formatting for key edge cases
- record the follow-up investigation and validation steps in the Issue 02.2.2 dev log

## Testing
- swift test --package-path Packages/CoreModels --filter TimeIntervalFormattingTests

------
https://chatgpt.com/codex/tasks/task_e_69021270bc0c8327ab3c07e834288bb5