### PR TITLE
Rename CI job: UITests-Playback → UITests-PlayerNavigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -806,7 +806,7 @@ jobs:
             tests: zpodUITests/CoreUINavigationTests,zpodUITests/EpisodeListUITests
           - name: UITests-ContentDiscovery
             tests: zpodUITests/ContentDiscoveryUITests
-          - name: UITests-Playback
+          - name: UITests-PlayerNavigation
             tests: zpodUITests/PlayerNavigationTests,zpodUITests/PlayerPlaybackInteractionTests,zpodUITests/PlayerOrientationSnapshotTests
           - name: UITests-CorePlayback
             tests: zpodUITests/PlaybackUITests

--- a/Issues/03.3.2.4-ci-configuration-dual-mode-tests.md
+++ b/Issues/03.3.2.4-ci-configuration-dual-mode-tests.md
@@ -37,7 +37,7 @@ matrix:
   include:
     - name: UITests-Navigation
     - name: UITests-ContentDiscovery
-    - name: UITests-Playback
+    - name: UITests-PlayerNavigation  # Player nav flows, mini-player, orientation
     - name: UITests-CorePlayback
     - name: UITests-BatchOperations
 ```


### PR DESCRIPTION
## Problem

The CI job name `UITests-Playback` was confusing because it suggested it tested playback position advancement, but it actually tests:
- **Player navigation flows** (Library → Podcast → Episode Detail)
- **Quick play & mini-player interactions**
- **Player orientation/layout snapshots**

This is **different** from the new dual-mode position tests:
- `UITests-PlaybackTicker` - Deterministic position advancement tests
- `UITests-PlaybackAVPlayer` - Real audio integration tests

## Solution

Renamed the job to **`UITests-PlayerNavigation`** for clarity.

## Changes

- ✅ Renamed `UITests-Playback` → `UITests-PlayerNavigation` in `.github/workflows/ci.yml`
- ✅ Updated documentation in `Issues/03.3.2.4`
- ✅ No functional changes - just improved naming

## Test Files Included

The renamed job still runs the same tests:
- `zpodUITests/PlayerNavigationTests` (3 tests)
- `zpodUITests/PlayerPlaybackInteractionTests` (3 tests)  
- `zpodUITests/PlayerOrientationSnapshotTests` (3 tests)

**Total**: 9 tests validating player UI flows and interactions

## Impact

- ✅ Clearer separation between navigation tests and position tests
- ✅ Better maintainability (obvious what each job tests)
- ✅ No CI runtime changes
- ✅ No test coverage changes