### PR TITLE
[#269] Decompose Issue 03.3.4 into 5 Sub-Issues

### DIFF
--- a/Issues/03.3.4-unplayable-episode-ux.md
+++ b/Issues/03.3.4-unplayable-episode-ux.md
@@ -22,12 +22,14 @@ This issue has been decomposed into 5 manageable sub-issues:
 
 ### 03.3.4.1: Extend PlaybackError Enum ⏱️ 30 min
 - **Status**: 🆕 Proposed
+- **GitHub**: [#318](https://github.com/ezigus/zpod/issues/318)
 - **File**: `Issues/03.3.4.1-playback-error-enum-extension.md`
 - **Purpose**: Add `.missingAudioURL`, `.networkError`, `.timeout` cases + `isRecoverable` property
 - **Dependencies**: None (foundation for other sub-issues)
 
 ### 03.3.4.2: Mini-Player Error UI ⏱️ 1.5 hours
 - **Status**: 🆕 Proposed
+- **GitHub**: [#319](https://github.com/ezigus/zpod/issues/319)
 - **File**: `Issues/03.3.4.2-mini-player-error-ui.md`
 - **Purpose**: Expose error in `MiniPlayerDisplayState`, show error overlay with retry button
 - **Dependencies**: Requires 03.3.4.1
@@ -35,6 +37,7 @@ This issue has been decomposed into 5 manageable sub-issues:
 
 ### 03.3.4.3: Expanded Player Error UI ⏱️ 1.5 hours
 - **Status**: 🆕 Proposed
+- **GitHub**: [#320](https://github.com/ezigus/zpod/issues/320)
 - **File**: `Issues/03.3.4.3-expanded-player-error-ui.md`
 - **Purpose**: Add `currentError` to ExpandedPlayerViewModel, show error view with retry button
 - **Dependencies**: Requires 03.3.4.1 (parallel with 03.3.4.2)
@@ -42,6 +45,7 @@ This issue has been decomposed into 5 manageable sub-issues:
 
 ### 03.3.4.4: AVPlayer Error Detection ⏱️ 1 hour
 - **Status**: 🆕 Proposed
+- **GitHub**: [#321](https://github.com/ezigus/zpod/issues/321)
 - **File**: `Issues/03.3.4.4-avplayer-error-detection.md`
 - **Purpose**: Add `mapAVError()` to map AVPlayer errors to PlaybackError cases
 - **Dependencies**: Requires 03.3.4.1
@@ -49,6 +53,7 @@ This issue has been decomposed into 5 manageable sub-issues:
 
 ### 03.3.4.5: Complete 03.3.2.7 Tests ⏱️ 30 min
 - **Status**: 🆕 Proposed
+- **GitHub**: [#322](https://github.com/ezigus/zpod/issues/322)
 - **File**: `Issues/03.3.4.5-complete-edge-case-tests.md`
 - **Purpose**: Remove `XCTSkip` from error tests in 03.3.2.7, verify they pass
 - **Dependencies**: Requires 03.3.4.1-03.3.4.4 all complete

--- a/Issues/03.3.4.1-playback-error-enum-extension.md
+++ b/Issues/03.3.4.1-playback-error-enum-extension.md
@@ -6,6 +6,8 @@
 
 **Parent**: 03.3.4 - Unplayable Episode UX & Diagnostics (#269)
 
+**GitHub Issue**: [#318](https://github.com/ezigus/zpod/issues/318)
+
 **Estimated Effort**: 30 minutes
 
 ## Description

--- a/Issues/03.3.4.2-mini-player-error-ui.md
+++ b/Issues/03.3.4.2-mini-player-error-ui.md
@@ -6,6 +6,8 @@
 
 **Parent**: 03.3.4 - Unplayable Episode UX & Diagnostics (#269)
 
+**GitHub Issue**: [#319](https://github.com/ezigus/zpod/issues/319)
+
 **Estimated Effort**: 1.5 hours
 
 ## Description

--- a/Issues/03.3.4.3-expanded-player-error-ui.md
+++ b/Issues/03.3.4.3-expanded-player-error-ui.md
@@ -6,6 +6,8 @@
 
 **Parent**: 03.3.4 - Unplayable Episode UX & Diagnostics (#269)
 
+**GitHub Issue**: [#320](https://github.com/ezigus/zpod/issues/320)
+
 **Estimated Effort**: 1.5 hours
 
 ## Description

--- a/Issues/03.3.4.4-avplayer-error-detection.md
+++ b/Issues/03.3.4.4-avplayer-error-detection.md
@@ -6,6 +6,8 @@
 
 **Parent**: 03.3.4 - Unplayable Episode UX & Diagnostics (#269)
 
+**GitHub Issue**: [#321](https://github.com/ezigus/zpod/issues/321)
+
 **Estimated Effort**: 1 hour (reduced - some infrastructure already exists)
 
 ## Description

--- a/Issues/03.3.4.5-complete-edge-case-tests.md
+++ b/Issues/03.3.4.5-complete-edge-case-tests.md
@@ -6,6 +6,8 @@
 
 **Parent**: 03.3.4 - Unplayable Episode UX & Diagnostics (#269)
 
+**GitHub Issue**: [#322](https://github.com/ezigus/zpod/issues/322)
+
 **Estimated Effort**: 30 minutes
 
 ## Description


### PR DESCRIPTION
## Summary

Broke down Issue #269 (03.3.4 - Unplayable Episode UX & Diagnostics) into 5 focused, manageable sub-issues with realistic time estimates and clear dependencies.

## Sub-Issues Created

1. **[#318](https://github.com/ezigus/zpod/issues/318)** - [03.3.4.1] Extend PlaybackError Enum (30 min)
   - Add `.missingAudioURL`, `.networkError`, `.timeout` cases
   - Add `isRecoverable` and `userMessage` properties
   - Foundation for all other sub-issues

2. **[#319](https://github.com/ezigus/zpod/issues/319)** - [03.3.4.2] Mini-Player Error UI (1.5 hours)
   - Add error field to `MiniPlayerDisplayState`
   - Show error overlay with retry button
   - Includes ViewModel changes to expose error state

3. **[#320](https://github.com/ezigus/zpod/issues/320)** - [03.3.4.3] Expanded Player Error UI (1.5 hours)
   - Add `currentError` to `ExpandedPlayerViewModel`
   - Show prominent error view with retry button
   - Includes ViewModel changes to expose error state

4. **[#321](https://github.com/ezigus/zpod/issues/321)** - [03.3.4.4] AVPlayer Error Detection (1 hour)
   - Add `mapAVError()` method for error mapping
   - Update existing nil URL check to use new error case
   - Reduced scope (some infrastructure already exists)

5. **[#322](https://github.com/ezigus/zpod/issues/322)** - [03.3.4.5] Complete 03.3.2.7 Tests (30 min)
   - Remove `XCTSkip` from 2 error tests
   - Verify tests pass with new error UI
   - Updates 03.3.2.7 to 90% complete (9/10 tests)

## Key Improvements

- ✅ Identified actual ViewModel patterns (`DisplayState` usage)
- ✅ Added ViewModel changes to UI issues (#319, #320)
- ✅ Discovered existing error infrastructure (reduced #321 scope)
- ✅ Added implementation reminders and accessibility notes
- ✅ Realistic time estimates based on actual complexity

## Total Estimated Effort

**5 hours** (realistic estimate including ViewModel work)

## Execution Order

1. Start with #318 (foundation - no dependencies)
2. Then #319, #320, #321 (can be done in parallel after #318)
3. Finally #322 (after all others complete)

## Impact

- **Unblocks**: Issue #311 (03.3.2.7 - AVPlayer Edge-Case Tests)
- **Completes**: Issue #269 (03.3.4 - Unplayable Episode UX)
- **User Value**: Clear error messages with retry for recoverable errors

## Files Changed

- ✅ Created 5 sub-issue files in `Issues/`
- ✅ Updated parent issue with sub-issue links
- ✅ All files include GitHub issue numbers

## Testing

No code changes in this PR - only issue decomposition and planning documentation.

Closes #269