### PR TITLE
Address PR #324 review comments: grammar and punctuation

### DIFF
--- a/Packages/SharedUtilities/Sources/SharedUtilities/PlaybackAlerts.swift
+++ b/Packages/SharedUtilities/Sources/SharedUtilities/PlaybackAlerts.swift
@@ -137,7 +137,7 @@ public extension PlaybackError {
   var userMessage: String {
     switch self {
     case .missingAudioURL:
-      return "This episode doesn't have audio available"
+      return "This episode doesn't have audio available."
     case .networkError:
       return "Unable to load episode. Check your connection."
     case .timeout:

--- a/Packages/SharedUtilities/Tests/SharedUtilitiesTests/PlaybackErrorTests.swift
+++ b/Packages/SharedUtilities/Tests/SharedUtilitiesTests/PlaybackErrorTests.swift
@@ -33,7 +33,7 @@ final class PlaybackErrorTests: XCTestCase {
     // Given: A missing audio URL error
     let error = PlaybackError.missingAudioURL
 
-    // When/Then: Missing URL errors cannot be recovered
+    // When/Then: Missing URL errors cannot be recovered from
     XCTAssertFalse(error.isRecoverable, "Missing audio URL errors are not recoverable")
   }
 
@@ -65,7 +65,7 @@ final class PlaybackErrorTests: XCTestCase {
     // Then: Should have appropriate user-facing message
     XCTAssertEqual(
       message,
-      "This episode doesn't have audio available",
+      "This episode doesn't have audio available.",
       "Missing URL should have clear user message"
     )
   }


### PR DESCRIPTION
## Summary
Addresses three code review comments on PR #324 (Issue 03.3.4.1 - PlaybackError enum extension).

## Changes

### 1. Grammar Fix (PlaybackErrorTests.swift:36)
**Before**: `// When/Then: Missing URL errors cannot be recovered`
**After**: `// When/Then: Missing URL errors cannot be recovered from`

Fixed incomplete verb phrase - "recovered from" is the correct idiomatic English usage when discussing error recovery.

### 2. Punctuation Consistency (PlaybackAlerts.swift:140)
**Before**: `return "This episode doesn't have audio available"`
**After**: `return "This episode doesn't have audio available."`

Added period for consistency with all other error messages in the `userMessage` property:
- ✅ `"Unable to load episode. Check your connection."`
- ✅ `"Loading timed out. Tap to retry."`
- ✅ `"The episode you were listening to is no longer available."`
- ✅ `"Your previous listening session expired."`
- ✅ `"We couldn't access your last listening position."`
- ✅ `"Playback failed. Please try again."`

### 3. Test Expectation Update (PlaybackErrorTests.swift:68)
**Before**: `"This episode doesn't have audio available"`
**After**: `"This episode doesn't have audio available."`

Updated test expectation to match the corrected error message with proper punctuation.

## Test Results
✅ All 105 SharedUtilities tests passing

## Related
- Parent PR: #324 (Issue 03.3.4.1 - PlaybackError Enum Extension)
- Fixes code review feedback from PR #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)