### PR TITLE
[#03.3.4.4] Improve AVPlayer error detection

### DIFF
--- a/Packages/PlaybackEngine/Tests/AVPlayerPlaybackEngineTests.swift
+++ b/Packages/PlaybackEngine/Tests/AVPlayerPlaybackEngineTests.swift
@@ -400,5 +400,24 @@ final class AVPlayerPlaybackEngineTests: XCTestCase {
         try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
         XCTAssertEqual(positionUpdateCountAfterError, 0, "Position updates should stop after error")
     }
+
+    func testMapAVErrorDetectsNetworkFailure() throws {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        XCTAssertEqual(engine.mapAVError(error), .networkError)
+    }
+
+    func testMapAVErrorDetectsTimeout() throws {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        XCTAssertEqual(engine.mapAVError(error), .timeout)
+    }
+
+    func testMapAVErrorDefaultsToUnknown() throws {
+        let error = NSError(
+            domain: "CustomDomain",
+            code: 1234,
+            userInfo: [NSLocalizedDescriptionKey: "Unexpected failure"]
+        )
+        XCTAssertEqual(engine.mapAVError(error), .unknown(message: "Unexpected failure"))
+    }
 }
 #endif

--- a/Packages/PlaybackEngine/Tests/EnhancedEpisodePlayerAudioIntegrationTests.swift
+++ b/Packages/PlaybackEngine/Tests/EnhancedEpisodePlayerAudioIntegrationTests.swift
@@ -90,7 +90,7 @@ final class EnhancedEpisodePlayerAudioIntegrationTests: XCTestCase {
     /// **Scenario**: Play Episode Without Audio URL
     /// **Given** an episode without an audio URL
     /// **When** play() is called
-    /// **Then** state transitions to .failed with episodeUnavailable error
+    /// **Then** state transitions to .failed with missingAudioURL error
     func testPlayWithoutAudioURL() async throws {
         // Given: An episode without audio URL
         let episode = Episode(
@@ -118,7 +118,7 @@ final class EnhancedEpisodePlayerAudioIntegrationTests: XCTestCase {
         
         // Then: Should receive error state
         await fulfillment(of: [errorExpectation], timeout: 5.0)
-        XCTAssertEqual(receivedError, .episodeUnavailable, "Should report episode unavailable")
+        XCTAssertEqual(receivedError, .missingAudioURL, "Should report missing audio URL")
     }
     
     // MARK: - Pause/Resume Tests

--- a/dev-log/03.3.4.4-avplayer-error-detection.md
+++ b/dev-log/03.3.4.4-avplayer-error-detection.md
@@ -1,0 +1,39 @@
+# Dev Log: Issue 03.3.4.4 — AVPlayer Error Detection
+
+**Issue**: [#321](https://github.com/ezigus/zpod/issues/321)  
+**Branch**: `03.3.4.4-error-detection`  
+**Status**: 🚧 In Progress  
+**Started**: 2026-01-09
+
+## Goal
+
+Bridge the gap between AVPlayer's raw failures and the `PlaybackError` enum so the player UI can show the right message, and log the diagnostic context (episode ID, URL, error code) for triage.
+
+## Design Strategy
+
+1. **Error mapping**  
+   AVPlayer/AVPlayerItem errors tend to surface as `NSError`s; create `AVPlayerPlaybackEngine.mapAVError(_:)` to translate common domains/codes (`NSURLErrorDomain` → `.networkError`/`.timeout`, `AVFoundationErrorDomain` → `.streamFailed`, fallback to `.unknown`).  
+2. **Failure observation**  
+   Extend the engine's existing status observer with the new mapping and add a listener for `AVPlayerItemFailedToPlayToEndTime` so we catch both KVO and notification-driven errors. Both paths should feed `onError` with the mapped `PlaybackError`.  
+3. **Logging & diagnostics**  
+   Log each failure in `EnhancedEpisodePlayer.failPlayback(error:)` using a dedicated `Logger` so the entry includes episode ID, title, audio URL, and the `PlaybackError`. This keeps domain knowledge (episode metadata) inside the player while surface-level errors stay inside the engine.  
+4. **Missing audio signal**  
+   When the enhanced player tries to use the AVPlayer engine but the episode lacks an audio URL, log the situation and emit `.missingAudioURL` instead of `.episodeUnavailable`, matching the spec.
+
+## Testing Plan
+
+- Extend `AVPlayerPlaybackEngineTests` with mapping-focused tests:
+  1. `mapAVError` returns `.networkError` for `NSURLErrorNotConnectedToInternet`.  
+  2. `mapAVError` returns `.timeout` for `NSURLErrorTimedOut`.  
+  3. `mapAVError` treats unexpected NSError as `.unknown` (with message).  
+- Add state-based check in `EnhancedEpisodePlayerAudioIntegrationTests` to confirm playing an episode without an audio URL transitions to `.failed(..., .missingAudioURL)`.
+- Confirm the existing invalid URL integration test still asserts `.streamFailed` (no logical change).
+
+## Tasks
+
+1. Implement `mapAVError` and wire it into `observePlayerStatus()` / failure notification.  
+2. Ensure `onError` always receives the mapped `PlaybackError`.  
+3. Add OSLog logger and detailed error logging inside `EnhancedEpisodePlayer.failPlayback(error:)`.  
+4. Update the nil-audio branch to use `.missingAudioURL`.  
+5. Add the new tests described above.  
+6. Record manual verification notes (VoiceOver or manual tests not needed for this issue; engine logic only).


### PR DESCRIPTION
## Summary
- translate AVPlayer failures into the new `PlaybackError` cases (network error, timeout, unknown) via a shared `mapAVError` helper and emit them through both the KVO status observer and `AVPlayerItemFailedToPlayToEndTime` notifications
- log the underlying NSError details and current URL before forwarding the mapped errors, and add diagnostic logging inside `EnhancedEpisodePlayer.failPlayback` so we capture episode metadata whenever a failure occurs
- update the enhanced player nil-audio branch to emit `.missingAudioURL` and adjust the integration test plus AVPlayer unit tests to assert the new mappings

## Testing
- `swift test --filter PlaybackEngineTests`
