### PR TITLE
[#03.3.3] Add real feed fixture and invalid enclosure logging

### DIFF
--- a/Packages/FeedParsing/Tests/FeedParsingTests/Fixtures/atp-feed-sample.xml
+++ b/Packages/FeedParsing/Tests/FeedParsingTests/Fixtures/atp-feed-sample.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+  <channel>
+    <title>Accidental Tech Podcast</title>
+    <description>Three nerds discussing tech, Apple, programming, and loosely related matters.</description>
+    <itunes:author>Marco Arment, Casey Liss, John Siracusa</itunes:author>
+    <item>
+      <title>675: Open, Retrieve, Expand, Load</title>
+      <guid isPermaLink="false">c1hrwkrnejz3b1do</guid>
+      <pubDate>Thu, 22 Jan 2026 20:21:59 +0000</pubDate>
+      <description>&lt;ul&gt;
+&lt;li&gt;Pre-show: Snowpocalypse is coming for Casey&lt;/li&gt;
+&lt;li&gt;🗣️ New &lt;a href=&quot;https://atp.fm/join&quot;&gt;ATP Member&amp;#8217;s&lt;/a&gt; Special: &lt;a href=&quot;https://atp.fm/atp-tier-list-automotive-logos&quot;&gt;ATP Tier List: Automotive Logos&lt;/a&gt; 🗣️&lt;/li&gt;
+&lt;li&gt;Follow-up:
+
+&lt;ul&gt;
+&lt;li&gt;We&amp;#8217;ll talk TCL/Sony next week!
+
+&lt;ul&gt;
+&lt;…</description>
+      <enclosure url="https://atp.fm/audio/c1hrwkrnejz3b1do/atp675.mp3" length="121016235" type="audio/mpeg"/>
+      <itunes:duration>02:06:03</itunes:duration>
+    </item>
+    <item>
+      <title>674: A Reliable, Boring Partner</title>
+      <guid isPermaLink="false">mmlultngwkhmalls</guid>
+      <pubDate>Fri, 16 Jan 2026 20:32:36 +0000</pubDate>
+      <description>&lt;ul&gt;
+&lt;li&gt;Pre-show: Casey&amp;#8217;s dreams were squashed
+
+&lt;ul&gt;
+&lt;li&gt;&lt;a href=&quot;https://store.ui.com/us/en/products/utr&quot;&gt;Ubiquiti Travel Router&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&quot;https://www.verizon.com/support/verizon-jetpack-mifi-8800l/&quot;&gt;Verizon Jetpack&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&quot;https://www.amazon.com/dp/B0CKY7NBJ2/tag=m…</description>
+      <enclosure url="https://atp.fm/audio/mmlultngwkhmalls/atp674.mp3" length="117110708" type="audio/mpeg"/>
+      <itunes:duration>02:01:25</itunes:duration>
+    </item>
+  </channel>
+</rss>

--- a/dev-log/03.3.3-feed-parsing-audio-url.md
+++ b/dev-log/03.3.3-feed-parsing-audio-url.md
@@ -19,3 +19,19 @@
 - Add sanitized fixtures from at least one real podcast feed (e.g., ATP, The Talk Show) and assert parsed `audioURL` and `duration`.
 - Add explicit logging for malformed enclosure URLs separate from missing URLs; unit test the malformed-path to ensure non-crashing behavior.
 - Keep issue 03.3.3 acceptance criteria aligned with the above before final closure.
+
+## 2026-01-25 07:56 ET — Follow-up plan (feature/03.3.3-followups)
+
+- Goals: (1) add real-world feed fixtures + tests to satisfy acceptance on sample podcasts; (2) add malformed `enclosure url` logging with dedicated unit coverage. Optional: capture enclosure length/type if extending Episode model later.
+- Approach:
+  - Gather 1–2 real feed samples, sanitize PII/URLs if needed, store under `Packages/FeedParsing/Tests/FeedParsingTests/Fixtures/`.
+  - Add parser tests that assert parsed `audioURL` and `duration` match feed data and that episodes without enclosures stay nil.
+  - Update `RSSFeedParser` logging to differentiate missing vs invalid URLs; add a malformed URL fixture and test to ensure logging + nil behavior without crashing.
+  - Re-run targeted FeedParsing tests locally to confirm coverage.
+
+## 2026-01-25 08:03 ET — Follow-up implementation notes
+
+- Added ATP real-feed fixture (`Fixtures/atp-feed-sample.xml`) with two live episodes to validate enclosure URLs and durations.
+- `RSSFeedParser` now injects a `logWarning` closure (Sendable), differentiates missing vs invalid enclosure URLs, and retains episodes with nil audioURL when invalid.
+- Added logging-focused test with malformed enclosure URL and warning capture; added fixture-based test against ATP sample feed to satisfy acceptance for real feeds.
+- Test run: `./scripts/run-xcode-tests.sh -t FeedParsingTests` (pass) — see `TestResults/TestResults_20260125_080315_test_pkg_FeedParsing.log`.


### PR DESCRIPTION
## Summary
- add real ATP feed fixture to exercise enclosure URL and duration parsing against live-style data
- distinguish missing vs malformed enclosure URLs with explicit logging while preserving episodes
- add tests for invalid enclosure logging and real-feed parsing; update dev-log

## Testing
- ./scripts/run-xcode-tests.sh -t FeedParsingTests