### PR TITLE
fix(ci): prevent CoreSimulator process accumulation in serial UI test runs

### DIFF
--- a/scripts/lib/harness.sh
+++ b/scripts/lib/harness.sh
@@ -1215,6 +1215,18 @@ run_ui_test_suites_serial() {
       fi
     fi
 
+    # Shut down the simulator between serial suites to let CoreSimulator tear down its
+    # process tree and prevent accumulation across 17+ suites (which hits the ~1333
+    # user-process limit). The next suite's xcodebuild invocation will reboot it.
+    local shutdown_udid="${ZPOD_SIMULATOR_UDID:-}"
+    if [[ -z "$shutdown_udid" ]]; then
+      shutdown_udid=$(_udid_for_destination "${ZPOD_DESTINATION:-}" 2>/dev/null) || true
+    fi
+    if [[ -n "$shutdown_udid" ]]; then
+      log_info "Shutting down simulator ${shutdown_udid} between suites to reclaim CoreSimulator processes"
+      xcrun simctl shutdown "$shutdown_udid" 2>/dev/null || true
+    fi
+
     if [[ -n "$temp_sim_udid" ]]; then
       cleanup_ephemeral_simulator "$temp_sim_udid"
       temp_sim_udid=""

--- a/scripts/lib/xcode.sh
+++ b/scripts/lib/xcode.sh
@@ -770,10 +770,20 @@ xcodebuild_wrapper() {
   while (( elapsed < timeout_seconds )); do
     # Check if xcodebuild is still running
     if ! kill -0 "$xcodebuild_pid" 2>/dev/null; then
-      # Process finished naturally
+      # Process finished naturally.
+      # Snapshot direct children before wait — after wait they are reparented to PID 1
+      # and pkill -P can no longer find them.
+      local child_pids
+      child_pids=$(pgrep -P "$xcodebuild_pid" 2>/dev/null) || true
       trap - INT  # Remove trap
       wait "$xcodebuild_pid"
       local exit_code=$?
+      # Kill any orphaned direct children that were reparented during wait
+      if [[ -n "$child_pids" ]]; then
+        for cpid in $child_pids; do
+          kill -TERM "$cpid" 2>/dev/null || true
+        done
+      fi
       ts_elapsed=$(( $(date +%s) - xb_start ))
       formatted_elapsed=$(printf '%02d:%02d:%02d' $((ts_elapsed/3600)) $(((ts_elapsed%3600)/60)) $((ts_elapsed%60)))
       log_time "xcodebuild completed in ${formatted_elapsed}"


### PR DESCRIPTION
## Summary

- **Fix 1 (primary)**: `scripts/lib/harness.sh` — shut down the simulator by UDID after each suite in `run_ui_test_suites_serial()`. Uses `_udid_for_destination` when `ZPOD_SIMULATOR_UDID` isn't set. xcodebuild reboots it fresh for the next suite automatically.
- **Fix 2 (belt-and-suspenders)**: `scripts/lib/xcode.sh` — snapshot xcodebuild's direct child PIDs with `pgrep -P` before calling `wait`, then SIGTERM them after `wait` returns. Children are reparented to PID 1 after wait, so `pkill -P` can't reach them post-hoc; snapshotting first closes that window.

## Root Cause

When `run-xcode-tests.sh` runs UI suites sequentially (the default, `ZPOD_UI_TEST_PARALLELISM=1`), CoreSimulator processes accumulate across suites because there was no between-suite cleanup. By suite 17+, the process count reaches 1200+ (out of a 1333 user-process limit), causing simulator resource exhaustion — tests hang waiting for the Accessibility framework, xcodebuild times out, and pipelines circuit-break.

## Test Plan

- [x] Ran `CoreUINavigationTests` and `LibraryViewUITests` back-to-back — process count stayed flat between suites (~1000), did not accumulate
- [x] Pre-existing test failure in `testSettingsTabPresentsSwipeActions` confirmed unrelated to this change
- [ ] Full regression validation: first Shipwright pipeline run through all 17+ UI suites should complete without hitting the process limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)