### PR TITLE
[#450] feat(settings): add Export Subscriptions (OPML) button to Settings

### DIFF
--- a/Packages/FeedParsing/Sources/FeedParsing/OPMLExportService.swift
+++ b/Packages/FeedParsing/Sources/FeedParsing/OPMLExportService.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreModels
 
 /// Service for exporting podcast subscriptions to OPML format
-public final class OPMLExportService {
+public final class OPMLExportService: @unchecked Sendable {
     
     /// Errors that can occur during OPML export
     public enum Error: Swift.Error, Equatable {

--- a/Packages/FeedParsing/Tests/FeedParsingTests/OPMLExportServiceTests.swift
+++ b/Packages/FeedParsing/Tests/FeedParsingTests/OPMLExportServiceTests.swift
@@ -64,7 +64,7 @@ private func makePodcast(
 /// - 0 integration / E2E tests (file-picker system sheet is outside unit scope)
 ///
 /// **Coverage Targets**:
-/// - Unit layer: 100% branch coverage of exportSubscriptions() and exportSubscriptionsAsXML()
+/// - Unit layer: 100% branch coverage of exportSubscriptions(), exportSubscriptionsAsXML(), and exportSubscriptionsAsXMLString()
 ///
 /// **Critical Paths**:
 /// - Happy path: subscribed podcasts → valid OPML document and XML data
@@ -153,19 +153,21 @@ final class OPMLExportServiceTests: XCTestCase {
     // MARK: - AC3: Output contains correct URLs
 
     /// Given: Subscribed podcasts with known feed URLs
-    /// When: exportSubscriptionsAsXMLString() is called
-    /// Then: Each feed URL appears in the XML output
+    /// When: exportSubscriptionsAsXML() is called (the method used by SettingsHomeView)
+    /// Then: The returned Data contains each feed URL and podcast title
     ///
-    /// **AC3** — feed URL correctness
-    func testExportSubscriptionsAsXMLString_containsFeedURLs() throws {
+    /// **AC3** — feed URL correctness; directly exercises the production code path
+    func testExportSubscriptionsAsXML_containsFeedURLs() throws {
         let feedURL = "https://podcast.example.com/rss"
         let manager = MockPodcastManager(podcasts: [
             makePodcast(title: "My Show", feedURL: feedURL),
         ])
         let service = OPMLExportService(podcastManager: manager)
 
-        let xml = try service.exportSubscriptionsAsXMLString()
+        let data = try service.exportSubscriptionsAsXML()
+        let xml = String(data: data, encoding: .utf8) ?? ""
 
+        XCTAssertFalse(data.isEmpty, "exportSubscriptionsAsXML() should return non-empty Data")
         XCTAssertTrue(xml.contains(feedURL), "XML output should contain the podcast feed URL")
         XCTAssertTrue(xml.contains("My Show"), "XML output should contain the podcast title")
     }

--- a/Packages/LibraryFeature/Sources/LibraryFeature/SettingsHomeView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/SettingsHomeView.swift
@@ -120,12 +120,14 @@ struct SettingsHomeView: View {
       ) { result in
         defer { exportDocument = nil }
         if case .failure(let error) = result {
+          // Ignore user-cancel — no error to surface when the user dismisses the picker
+          guard (error as? CocoaError)?.code != .userCancelled else { return }
           exportErrorMessage = error.localizedDescription
           showExportError = true
         }
       }
       .alert("Export Failed", isPresented: $showExportError) {
-        Button("OK", role: .cancel) {}
+        Button("OK") {}
       } message: {
         Text(exportErrorMessage)
       }
@@ -162,27 +164,40 @@ struct SettingsHomeView: View {
     orphanedCount = PlaybackEnvironment.podcastManager.fetchOrphanedEpisodes().count
   }
 
+  private enum OPMLExportOutcome: Sendable {
+    case success(Data)
+    case failure(String)
+  }
+
   @MainActor
   private func exportOPML() {
     // PlaybackEnvironment.podcastManager is always non-nil: CarPlayDependencyRegistry falls
     // back to EmptyPodcastManager() when unconfigured, so early-init calls will produce a
     // .noSubscriptions error rather than crashing.
-    let service = OPMLExportService(podcastManager: PlaybackEnvironment.podcastManager)
-    do {
-      let data = try service.exportSubscriptionsAsXML()
-      guard !data.isEmpty else {
-        exportErrorMessage = "Export produced an empty file. Please try again."
-        showExportError = true
-        return
+    let podcastManager = PlaybackEnvironment.podcastManager
+    Task.detached(priority: .userInitiated) {
+      let outcome: OPMLExportOutcome
+      do {
+        let service = OPMLExportService(podcastManager: podcastManager)
+        let data = try service.exportSubscriptionsAsXML()
+        outcome = data.isEmpty
+          ? .failure("Export produced an empty file. Please try again.")
+          : .success(data)
+      } catch OPMLExportService.Error.noSubscriptions {
+        outcome = .failure("You have no subscriptions to export.")
+      } catch {
+        outcome = .failure(error.localizedDescription)
       }
-      exportDocument = OPMLFileDocument(data: data)
-      isExportPresented = true
-    } catch OPMLExportService.Error.noSubscriptions {
-      exportErrorMessage = "You have no subscriptions to export."
-      showExportError = true
-    } catch {
-      exportErrorMessage = error.localizedDescription
-      showExportError = true
+      await MainActor.run {
+        switch outcome {
+        case .success(let data):
+          self.exportDocument = OPMLFileDocument(data: data)
+          self.isExportPresented = true
+        case .failure(let message):
+          self.exportErrorMessage = message
+          self.showExportError = true
+        }
+      }
     }
   }
 

--- a/Packages/LibraryFeature/Tests/LibraryFeatureTests/OPMLFileDocumentTests.swift
+++ b/Packages/LibraryFeature/Tests/LibraryFeatureTests/OPMLFileDocumentTests.swift
@@ -26,7 +26,7 @@ import UniformTypeIdentifiers
 /// Unit tests for OPMLFileDocument.
 ///
 /// **Test Pyramid Breakdown**:
-/// - 3 unit tests covering the constructable surface of OPMLFileDocument
+/// - 4 unit tests covering the constructable surface of OPMLFileDocument
 /// - 0 integration / E2E tests (FileDocument is a SwiftUI protocol bridge; the file-exporter
 ///   pipeline is exercised by SettingsExportOPMLUITests)
 ///
@@ -68,6 +68,30 @@ final class OPMLFileDocumentTests: XCTestCase {
 
         XCTAssertTrue(document.data.isEmpty,
             "OPMLFileDocument must accept and preserve empty Data without substitution")
+    }
+
+    // MARK: - AC1: Data preservation — large payload
+
+    /// Given: An OPMLFileDocument initialised with a large Data payload (representative of a
+    ///        library with thousands of subscriptions)
+    /// When: The document's data property is accessed
+    /// Then: Every byte is preserved without truncation
+    ///
+    /// **AC1** — large-data preservation edge case
+    func testInit_largeData_storesDataUnchanged() {
+        // ~500 KB of repeating OPML-like content; large enough to catch any buffer/truncation
+        // issue without making the test suite meaningfully slower.
+        let repeatingUnit = Data("<outline text=\"Podcast\" xmlUrl=\"https://example.com/feed\"/>".utf8)
+        var largeData = Data()
+        largeData.reserveCapacity(repeatingUnit.count * 10_000)
+        for _ in 0..<10_000 { largeData.append(repeatingUnit) }
+
+        let document = OPMLFileDocument(data: largeData)
+
+        XCTAssertEqual(document.data.count, largeData.count,
+            "OPMLFileDocument must preserve large payloads without truncation")
+        XCTAssertEqual(document.data, largeData,
+            "OPMLFileDocument must store large payloads byte-for-byte")
     }
 
     // MARK: - AC1: Readable content types

--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -7,7 +7,7 @@ fi
 __ZPOD_LOGGING_SH=1
 
 # ANSI colour codes (fall back to no colour when not a TTY)
-if [[ -t 1 ]]; then
+if [[ -t 1 && -t 2 ]]; then
   __LOG_RESET="\033[0m"
   __LOG_BLUE="\033[0;34m"
   __LOG_GREEN="\033[0;32m"
@@ -35,7 +35,7 @@ log_success() {
 }
 
 log_warn() {
-  printf "%b\n" "${__LOG_YELLOW}⚠️  ${*}${__LOG_RESET}"
+  printf "%b\n" "${__LOG_YELLOW}⚠️  ${*}${__LOG_RESET}" >&2
 }
 
 log_error() {

--- a/zpodUITests/SettingsExportOPMLUITests.swift
+++ b/zpodUITests/SettingsExportOPMLUITests.swift
@@ -123,6 +123,18 @@ final class SettingsExportOPMLUITests: IsolatedUITestCase {
       "Export Failed alert should appear when there are no subscriptions"
     )
 
+    let alertTitle = alert.staticTexts["Export Failed"].firstMatch
+    XCTAssertTrue(
+      alertTitle.waitForExistence(timeout: adaptiveShortTimeout),
+      "Alert title should be 'Export Failed' for the no-subscriptions error"
+    )
+
+    let alertMessage = alert.staticTexts["You have no subscriptions to export."].firstMatch
+    XCTAssertTrue(
+      alertMessage.waitForExistence(timeout: adaptiveShortTimeout),
+      "Alert message should confirm there are no subscriptions to export"
+    )
+
     // Dismiss the alert
     let okButton = alert.buttons["OK"].firstMatch
     XCTAssertTrue(okButton.waitForExistence(timeout: adaptiveShortTimeout), "OK button should be present")

--- a/zpodUITests/TestSummary.md
+++ b/zpodUITests/TestSummary.md
@@ -309,7 +309,7 @@ Each test phase time excludes the initial build (handled once by preflight). The
 | 4 | `testImportButtonIsAccessible` | AC1 — Import button has correct accessibility properties |
 | 5 | `testResultViewIdentifierIsReachableAfterSuccessfulImport` | AC3 — Result sheet appears via `UITEST_OPML_MOCK=success` |
 | 6 | `testErrorAlertAppearsOnInvalidFile` | AC4/AC5 — Error alert surfaces via `UITEST_OPML_MOCK=error_invalid` |
-| 7 | *(additional coverage)* | AC coverage for edge paths |
+| 7 | `testBackNavigationFromOPMLImportReturnsToSettings` | AC5 — back navigation returns to Settings screen |
 
 ### Export Subscriptions (OPML) UI Tests (`SettingsExportOPMLUITests.swift`)
 


### PR DESCRIPTION
## Summary

- Adds an **Export Subscriptions** button to the Settings screen (Data & Subscriptions section) that exports all subscribed podcast feeds as an OPML file
- Implements `OPMLFileDocument` wrapper conforming to `FileDocument` for `fileExporter` integration
- Wires the export button to `OPMLExportService.exportSubscriptionsAsXML()` with full error handling: empty data, no subscriptions, and general export failures
- Uses `UTType(filenameExtension: "opml") ?? .xml` for correct file type with graceful fallback

## Test plan

- [ ] Unit tests: `OPMLExportServiceTests` — 7 tests covering empty library, unsubscribed feeds, filtering, sort order, XML escaping
- [ ] Unit tests: `OPMLFileDocumentTests` — 3 tests covering data round-trip, empty data handling, readable content types
- [ ] UI tests: `SettingsExportOPMLUITests` — 3 tests: button visibility, file picker presentation, empty-library alert
- [ ] Manual: tap Export Subscriptions → file picker appears → save file → verify valid OPML XML

## Closes

Closes #450

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)