### PR TITLE
[#456] fix(player): restructure mini-player to fix nested button hit-testing and tab bar race condition

### DIFF
--- a/Packages/PlayerFeature/Sources/PlayerFeature/MiniPlayerView.swift
+++ b/Packages/PlayerFeature/Sources/PlayerFeature/MiniPlayerView.swift
@@ -43,64 +43,64 @@ public struct MiniPlayerView: View {
   // MARK: - Subviews ---------------------------------------------------------
 
   /// Issue 03.1.1.7: Tab bar extension mini-player (full-width, flush against tab bar).
-  ///
-  /// Uses a Button for the expand action instead of `.onTapGesture` +
-  /// `.contentShape(Rectangle())`. The gesture-based approach creates a
-  /// UITapGestureRecognizer that, when placed via `.safeAreaInset(edge: .bottom)`,
-  /// intercepts tab bar taps and prevents tab switching.
   @ViewBuilder
   private func miniPlayerCard(for episode: Episode, state: MiniPlayerDisplayState) -> some View {
-    Button {
-      onTapExpand()
-    } label: {
-      VStack(spacing: 0) {
-        Divider()
-          .frame(height: 1)
-          .padding(.top, 8)
+    VStack(spacing: 0) {
+      Divider()
+        .frame(height: 1)
+        .padding(.top, 8)
 
-        HStack(spacing: 12) {
-          artwork(for: episode)
+      HStack(spacing: 12) {
+        // Uses a Button for the expand action instead of `.onTapGesture` +
+        // `.contentShape(Rectangle())`. The gesture-based approach creates a
+        // UITapGestureRecognizer that, when placed via `.safeAreaInset(edge: .bottom)`,
+        // intercepts tab bar taps and prevents tab switching.
+        // The expand button wraps only artwork + title/subtitle so that transport
+        // controls remain independently tappable as siblings in the HStack.
+        Button {
+          onTapExpand()
+        } label: {
+          HStack(spacing: 12) {
+            artwork(for: episode)
 
-          VStack(alignment: .leading, spacing: 4) {
-            Text(episode.title)
-              .font(.subheadline)
-              .fontWeight(.semibold)
-              .lineLimit(1)
-              .accessibilityIdentifier("Mini Player Episode Title")
-
-            // Show error overlay if present, otherwise show podcast subtitle
-            if let error = state.error {
-              errorContent(for: error)
-            } else if !episode.podcastTitle.isEmpty {
-              Text(episode.podcastTitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 4) {
+              Text(episode.title)
+                .font(.subheadline)
+                .fontWeight(.semibold)
                 .lineLimit(1)
-                .accessibilityIdentifier("Mini Player Podcast Title")
-            }
-          }
-          .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityIdentifier("Mini Player Episode Title")
 
-          // Show transport controls only when no error
-          if state.error == nil {
-            transportControls(state: state)
+              // Show error overlay if present, otherwise show podcast subtitle
+              if let error = state.error {
+                errorContent(for: error)
+              } else if !episode.podcastTitle.isEmpty {
+                Text(episode.podcastTitle)
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+                  .lineLimit(1)
+                  .accessibilityIdentifier("Mini Player Podcast Title")
+              }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
           }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("Mini Player")
+        .accessibilityLabel(miniPlayerAccessibilityLabel(for: episode, error: state.error))
+        .accessibilityHint("Opens the full player")
+
+        // Transport controls are siblings, NOT inside the expand button
+        if state.error == nil {
+          transportControls(state: state)
+        }
       }
-      .background(.bar)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 10)
     }
-    .buttonStyle(.plain)
-    .accessibilityElement(children: .ignore)
-    .accessibilityIdentifier("Mini Player")
-    .accessibilityLabel(miniPlayerAccessibilityLabel(for: episode, error: state.error))
-    .accessibilityHint("Opens the full player")
-    .transition(
-      ProcessInfo.processInfo.environment["UITEST_DISABLE_ANIMATIONS"] == "1"
-        ? .identity
-        : .move(edge: .bottom).combined(with: .opacity)
-    )
+    .background(.bar)
+    // Transition is owned by the ContentView call site (.safeAreaInset conditional);
+    // do not add a second transition here or it will compose with the outer one.
   }
 
   private func miniPlayerAccessibilityLabel(

--- a/Packages/PlayerFeature/Sources/PlayerFeature/MiniPlayerView.swift
+++ b/Packages/PlayerFeature/Sources/PlayerFeature/MiniPlayerView.swift
@@ -70,10 +70,7 @@ public struct MiniPlayerView: View {
                 .lineLimit(1)
                 .accessibilityIdentifier("Mini Player Episode Title")
 
-              // Show error overlay if present, otherwise show podcast subtitle
-              if let error = state.error {
-                errorContent(for: error)
-              } else if !episode.podcastTitle.isEmpty {
+              if state.error == nil, !episode.podcastTitle.isEmpty {
                 Text(episode.podcastTitle)
                   .font(.caption)
                   .foregroundStyle(.secondary)
@@ -90,8 +87,11 @@ public struct MiniPlayerView: View {
         .accessibilityLabel(miniPlayerAccessibilityLabel(for: episode, error: state.error))
         .accessibilityHint("Opens the full player")
 
-        // Transport controls are siblings, NOT inside the expand button
-        if state.error == nil {
+        // Interactive controls are siblings so their taps are never swallowed
+        // by the expand button's gesture recognizer.
+        if let error = state.error {
+          errorContent(for: error)
+        } else {
           transportControls(state: state)
         }
       }

--- a/zpod/ContentViewBridge.swift
+++ b/zpod/ContentViewBridge.swift
@@ -110,9 +110,9 @@ private struct UITestTabBarIdentifierSetter: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> TabBarConfigViewController {
         let controller = TabBarConfigViewController()
-        controller.onViewDidAppear = { [coordinator = context.coordinator] in
+        controller.onViewDidAppear = { [coordinator = context.coordinator, weak controller] in
             guard !coordinator.isConfigured else { return }
-            if let tabBar = controller.locateTabBar() {
+            if let tabBar = controller?.locateTabBar() {
                 coordinator.isConfigured = true
                 configure(tabBar: tabBar)
             }

--- a/zpod/ContentViewBridge.swift
+++ b/zpod/ContentViewBridge.swift
@@ -112,10 +112,11 @@ private struct UITestTabBarIdentifierSetter: UIViewControllerRepresentable {
         let controller = TabBarConfigViewController()
         controller.onViewDidAppear = { [coordinator = context.coordinator] in
             guard !coordinator.isConfigured else { return }
-            coordinator.isConfigured = true
             if let tabBar = controller.locateTabBar() {
+                coordinator.isConfigured = true
                 configure(tabBar: tabBar)
             }
+            // If locateTabBar() returns nil, don't set isConfigured — viewDidAppear can retry
         }
         return controller
     }
@@ -164,7 +165,8 @@ final class TabBarConfigViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         onViewDidAppear?()
-        onViewDidAppear = nil  // fire once, then release
+        // Don't nil here — the closure guards with isConfigured,
+        // and we may need to retry if tab bar wasn't available yet
     }
 
     func locateTabBar() -> UITabBar? {


### PR DESCRIPTION
## Summary

- **MiniPlayerView**: Restructured `miniPlayerCard` so the expand `Button` wraps only the artwork + title/subtitle area. Transport controls are now siblings in the outer `HStack`, not nested inside the expand button. This prevents SwiftUI's nested-button hit-testing from swallowing transport control taps.
- **MiniPlayerView**: Removed duplicate `.transition()` from inside `miniPlayerCard`. The transition is owned and applied by `ContentView`'s `.safeAreaInset` conditional; a second identical transition inside the component composed on top of it, producing a double-slide visual artifact.
- **ContentViewBridge**: Fixed race condition where `coordinator.isConfigured = true` was set before `locateTabBar()` succeeded. If the tab bar wasn't available on first `viewDidAppear`, it was permanently skipped. Now `isConfigured` is only set on success, and `onViewDidAppear` is not nilled so retries are possible on subsequent appearances.

## Test plan

- [x] Syntax gate: `./scripts/run-xcode-tests.sh -s` — pass
- [x] `./scripts/run-xcode-tests.sh zpodUITests/PlayerPlaybackInteractionTests.swift` — 3/3 pass
- [x] `./scripts/run-xcode-tests.sh zpodUITests/PlaybackPositionAVPlayerTests.swift` — all pass
- [ ] Full regression CI run in progress

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)