### PR TITLE
fix(project): correct self-referencing package path for worktree compatibility

### DIFF
--- a/zpod.xcodeproj/project.pbxproj
+++ b/zpod.xcodeproj/project.pbxproj
@@ -500,7 +500,7 @@
 				786D3A032E57355D005A436B /* XCLocalSwiftPackageReference "Packages/Persistence" */,
 				786D3A042E57356F005A436B /* XCLocalSwiftPackageReference "Packages/SettingsDomain" */,
 				786D3A052E57357C005A436B /* XCLocalSwiftPackageReference "Packages/SharedUtilities" */,
-				786D3A062E573717005A436B /* XCLocalSwiftPackageReference "../zpod" */,
+				786D3A062E573717005A436B /* XCLocalSwiftPackageReference "." */,
 				78BF3E662E577C3A001DB480 /* XCLocalSwiftPackageReference "Packages/PlaybackEngine" */,
 				78BF3E672E577C40001DB480 /* XCLocalSwiftPackageReference "Packages/SearchDomain" */,
 				78BF3E682E577C45001DB480 /* XCLocalSwiftPackageReference "Packages/DiscoverFeature" */,
@@ -1048,9 +1048,9 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/SharedUtilities;
 		};
-		786D3A062E573717005A436B /* XCLocalSwiftPackageReference "../zpod" */ = {
+		786D3A062E573717005A436B /* XCLocalSwiftPackageReference "." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../zpod;
+			relativePath = .;
 		};
 		78BF3E662E577C3A001DB480 /* XCLocalSwiftPackageReference "Packages/PlaybackEngine" */ = {
 			isa = XCLocalSwiftPackageReference;


### PR DESCRIPTION
## Summary
- The `zpodLib` local package reference in `project.pbxproj` used `../zpod` as its relative path
- This only resolved correctly from the main checkout by coincidence (parent dir `code/` contains `zpod/`)
- In git worktrees (e.g. `.worktrees/pipeline-issue-478/`), the path resolved to `.worktrees/zpod` — which doesn't exist — breaking all `xcodebuild` scheme listing and builds
- Changed the relative path to `.` which correctly references the repo root `Package.swift` regardless of checkout location

## Test plan
- [x] Verified `xcodebuild -workspace zpod.xcworkspace -list` resolves all 19 schemes after the change
- [ ] Run `./scripts/run-xcode-tests.sh -s` (syntax gate)
- [ ] Run a worktree-based pipeline to confirm builds succeed in isolation

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)