### PR TITLE
fix(tests): resolve two pre-existing CI flaky test root causes

### DIFF
--- a/Packages/CoreModels/Sources/CoreModels/PlaybackSettings.swift
+++ b/Packages/CoreModels/Sources/CoreModels/PlaybackSettings.swift
@@ -130,4 +130,18 @@ public struct PodcastPlaybackSettings: Codable, Equatable, Sendable {
     public var outroSkipDuration: Int?
     public var skipForwardInterval: Int?
     public var skipBackwardInterval: Int?
+
+    public init(
+        speed: Double? = nil,
+        introSkipDuration: Int? = nil,
+        outroSkipDuration: Int? = nil,
+        skipForwardInterval: Int? = nil,
+        skipBackwardInterval: Int? = nil
+    ) {
+        self.speed = speed
+        self.introSkipDuration = introSkipDuration
+        self.outroSkipDuration = outroSkipDuration
+        self.skipForwardInterval = skipForwardInterval
+        self.skipBackwardInterval = skipBackwardInterval
+    }
 }

--- a/Packages/LibraryFeature/Package.swift
+++ b/Packages/LibraryFeature/Package.swift
@@ -57,6 +57,8 @@ let package = Package(
         .product(name: "SharedUtilities", package: "SharedUtilities"),
         .product(name: "CombineSupport", package: "CombineSupport"),
         .product(name: "FeedParsing", package: "FeedParsing"),
+        .product(name: "SettingsDomain", package: "SettingsDomain"),
+        .product(name: "Persistence", package: "Persistence"),
       ]
     ),
   ]

--- a/Packages/LibraryFeature/Sources/LibraryFeature/ContentView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/ContentView.swift
@@ -528,7 +528,7 @@ private let logger = Logger(subsystem: "us.zig.zpod.library", category: "TestAud
       ZStack(alignment: .bottom) {
         TabView(selection: $selectedTab) {
           // Library Tab (existing functionality)
-          LibraryView(podcastManager: podcastManager, playlistManager: playlistManager, refreshTrigger: libraryRefreshTrigger)
+          LibraryView(podcastManager: podcastManager, playlistManager: playlistManager, refreshTrigger: libraryRefreshTrigger, settingsManager: settingsManager)
             .tabItem {
               Label("Library", systemImage: "books.vertical")
             }
@@ -678,6 +678,7 @@ private let logger = Logger(subsystem: "us.zig.zpod.library", category: "TestAud
     let podcastManager: PodcastManaging
     let playlistManager: (any PlaylistManaging)?
     let refreshTrigger: Int
+    let settingsManager: SettingsManager
 
     @State private var podcasts: [Podcast] = []
     @State private var isLoading = true
@@ -687,10 +688,11 @@ private let logger = Logger(subsystem: "us.zig.zpod.library", category: "TestAud
       category: "LibraryView"
     )
 
-    init(podcastManager: PodcastManaging, playlistManager: (any PlaylistManaging)? = nil, refreshTrigger: Int = 0) {
+    init(podcastManager: PodcastManaging, playlistManager: (any PlaylistManaging)? = nil, refreshTrigger: Int = 0, settingsManager: SettingsManager) {
       self.podcastManager = podcastManager
       self.playlistManager = playlistManager
       self.refreshTrigger = refreshTrigger
+      self.settingsManager = settingsManager
     }
 
     var body: some View {
@@ -726,7 +728,7 @@ private let logger = Logger(subsystem: "us.zig.zpod.library", category: "TestAud
 
               // Card-based podcast layout (no table structure)
               ForEach(podcasts, id: \.id) { podcast in
-                PodcastCardView(podcast: podcast, playlistManager: playlistManager)
+                PodcastCardView(podcast: podcast, playlistManager: playlistManager, settingsManager: settingsManager)
                   .padding(.horizontal)
               }
             }
@@ -777,6 +779,9 @@ private let logger = Logger(subsystem: "us.zig.zpod.library", category: "TestAud
   private struct PodcastCardView: View {
     let podcast: Podcast
     let playlistManager: (any PlaylistManaging)?
+    let settingsManager: SettingsManager
+
+    @State private var showingCustomSettings = false
 
     var body: some View {
       NavigationLink(
@@ -823,6 +828,17 @@ private let logger = Logger(subsystem: "us.zig.zpod.library", category: "TestAud
       .accessibilityLabel(podcast.title)
       .accessibilityHint("Opens episode list for \(podcast.title)")
       .accessibilityAddTraits(.isButton)
+      .contextMenu {
+        Button {
+          showingCustomSettings = true
+        } label: {
+          Label("Custom Settings\u{2026}", systemImage: "gearshape")
+        }
+        .accessibilityIdentifier("Podcast-\(podcast.id).CustomSettings")
+      }
+      .sheet(isPresented: $showingCustomSettings) {
+        PodcastCustomSettingsView(podcast: podcast, settingsManager: settingsManager)
+      }
     }
   }
 

--- a/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
@@ -135,6 +135,11 @@ public struct EpisodeListView: View {
     .refreshable {
       await refreshEpisodes()
     }
+    // TODO: [#06.5.2] EpisodeListView gets settingsManager from EpisodeListDependencyProvider
+    // (test-suite-aware), while the Library context-menu entry point gets it from ContentView
+    // (UserDefaults.standard). In production both resolve to standard UserDefaults; in tests
+    // with UITEST_USER_DEFAULTS_SUITE set they diverge. Unify by threading settingsManager
+    // through EpisodeListView.init() when 06.5.2 wires more settings controls.
     .sheet(isPresented: $showingCustomSettings) {
       PodcastCustomSettingsView(
         podcast: podcast,

--- a/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
@@ -120,19 +120,15 @@ public struct EpisodeListView: View {
           } label: {
             Image(systemName: "gearshape")
           }
-          .accessibilityRepresentation {
-            Button("Custom Settings") {}
-              .accessibilityIdentifier("PodcastCustomSettingsButton")
-          }
+          .accessibilityIdentifier("PodcastCustomSettingsButton")
+          .accessibilityLabel("Custom Settings")
           Button {
             viewModel.showingSwipeConfiguration = true
           } label: {
             Image(systemName: "slider.horizontal.3")
           }
-          .accessibilityRepresentation {
-            Button("Configure Swipe Actions") {}
-              .accessibilityIdentifier("ConfigureSwipeActions")
-          }
+          .accessibilityIdentifier("ConfigureSwipeActions")
+          .accessibilityLabel("Configure Swipe Actions")
         }
       }
     }

--- a/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
@@ -44,6 +44,7 @@ public struct EpisodeListView: View {
   @StateObject private var viewModel: EpisodeListViewModel
   @State private var isRefreshing = false
   @State private var addToPlaylistEpisode: Episode? = nil
+  @State private var showingCustomSettings = false
 
   @MainActor
   public init(podcast: Podcast, filterManager: EpisodeFilterManager? = nil, playlistManager: (any PlaylistManaging)? = nil) {
@@ -115,6 +116,15 @@ public struct EpisodeListView: View {
             viewModel.enterMultiSelectMode()
           }
           Button {
+            showingCustomSettings = true
+          } label: {
+            Image(systemName: "gearshape")
+          }
+          .accessibilityRepresentation {
+            Button("Custom Settings") {}
+              .accessibilityIdentifier("PodcastCustomSettingsButton")
+          }
+          Button {
             viewModel.showingSwipeConfiguration = true
           } label: {
             Image(systemName: "slider.horizontal.3")
@@ -128,6 +138,12 @@ public struct EpisodeListView: View {
     }
     .refreshable {
       await refreshEpisodes()
+    }
+    .sheet(isPresented: $showingCustomSettings) {
+      PodcastCustomSettingsView(
+        podcast: podcast,
+        settingsManager: EpisodeListDependencyProvider.shared.settingsManager
+      )
     }
     .sheet(isPresented: $viewModel.showingFilterSheet) {
       EpisodeFilterSheet(

--- a/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift
@@ -135,7 +135,7 @@ public struct EpisodeListView: View {
     .refreshable {
       await refreshEpisodes()
     }
-    // TODO: [#06.5.2] EpisodeListView gets settingsManager from EpisodeListDependencyProvider
+    // TODO: [Issue #06.5.2] EpisodeListView gets settingsManager from EpisodeListDependencyProvider
     // (test-suite-aware), while the Library context-menu entry point gets it from ContentView
     // (UserDefaults.standard). In production both resolve to standard UserDefaults; in tests
     // with UITEST_USER_DEFAULTS_SUITE set they diverge. Unify by threading settingsManager

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
@@ -109,7 +109,7 @@ public struct PodcastCustomSettingsView: View {
             Button("Cancel", role: .cancel) { showResetConfirmation = false }
                 .accessibilityIdentifier("PodcastCustomSettings.ResetCancelButton")
             Button("Reset", role: .destructive) {
-                Task {
+                Task { @MainActor in
                     await viewModel.resetSettings()?.value
                     dismiss()
                 }

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
@@ -110,11 +110,12 @@ public struct PodcastCustomSettingsView: View {
                 }
             }
         }
-        .confirmationDialog(
+        .alert(
             "Reset Settings",
-            isPresented: $showResetConfirmation,
-            titleVisibility: .visible
+            isPresented: $showResetConfirmation
         ) {
+            Button("Cancel", role: .cancel) { showResetConfirmation = false }
+                .accessibilityIdentifier("PodcastCustomSettings.ResetCancelButton")
             Button("Reset", role: .destructive) {
                 Task {
                     await viewModel.resetSettings()?.value
@@ -122,8 +123,6 @@ public struct PodcastCustomSettingsView: View {
                 }
             }
             .accessibilityIdentifier("PodcastCustomSettings.ResetConfirmButton")
-            Button("Cancel") { showResetConfirmation = false }
-                .accessibilityIdentifier("PodcastCustomSettings.ResetCancelButton")
         } message: {
             Text(
                 "Reset all custom settings for \(viewModel.podcast.title)? This cannot be undone."

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
@@ -37,6 +37,32 @@ public struct PodcastCustomSettingsView: View {
     public var body: some View {
         NavigationStack {
             Form {
+                Section {
+                    Button(role: .destructive) {
+                        showResetConfirmation = true
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if viewModel.isResetting {
+                                ProgressView()
+                                    .padding(.trailing, 8)
+                            }
+                            Text("Reset to Global Defaults")
+                            Spacer()
+                        }
+                    }
+                    .disabled(viewModel.isResetting)
+                    .accessibilityIdentifier("PodcastCustomSettings.ResetButton")
+                }
+
+                if let error = viewModel.resetError {
+                    Section {
+                        Text(error)
+                            .foregroundColor(.red)
+                            .accessibilityIdentifier("PodcastCustomSettings.ErrorMessage")
+                    }
+                }
+
                 Section(header: Text("Download Settings")) {
                     Text("Custom download settings coming in a future update.")
                         .foregroundColor(.secondary)
@@ -71,32 +97,6 @@ public struct PodcastCustomSettingsView: View {
                     Text("Custom notification settings coming in a future update.")
                         .foregroundColor(.secondary)
                         .accessibilityIdentifier("PodcastCustomSettings.NotificationPlaceholder")
-                }
-
-                if let error = viewModel.resetError {
-                    Section {
-                        Text(error)
-                            .foregroundColor(.red)
-                            .accessibilityIdentifier("PodcastCustomSettings.ErrorMessage")
-                    }
-                }
-
-                Section {
-                    Button(role: .destructive) {
-                        showResetConfirmation = true
-                    } label: {
-                        HStack {
-                            Spacer()
-                            if viewModel.isResetting {
-                                ProgressView()
-                                    .padding(.trailing, 8)
-                            }
-                            Text("Reset to Global Defaults")
-                            Spacer()
-                        }
-                    }
-                    .disabled(viewModel.isResetting)
-                    .accessibilityIdentifier("PodcastCustomSettings.ResetButton")
                 }
             }
             .navigationTitle(viewModel.podcast.title)

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
@@ -55,14 +55,6 @@ public struct PodcastCustomSettingsView: View {
                     .accessibilityIdentifier("PodcastCustomSettings.ResetButton")
                 }
 
-                if let error = viewModel.resetError {
-                    Section {
-                        Text(error)
-                            .foregroundColor(.red)
-                            .accessibilityIdentifier("PodcastCustomSettings.ErrorMessage")
-                    }
-                }
-
                 Section(header: Text("Download Settings")) {
                     Text("Custom download settings coming in a future update.")
                         .foregroundColor(.secondary)

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
@@ -1,0 +1,133 @@
+//
+//  PodcastCustomSettingsView.swift
+//  LibraryFeature
+//
+//  Created for Issue #478: [06.5.1] PodcastCustomSettingsView scaffolding, access points,
+//  and Reset All.
+//
+//  This is the outer scaffold for per-podcast custom settings. Placeholder sections
+//  will be replaced with real controls in 06.5.2+.
+//
+
+import CoreModels
+import SettingsDomain
+import SwiftUI
+
+/// Per-podcast settings view — scaffold with placeholder sections and functional Reset All.
+///
+/// Entry points:
+/// - Long-press context menu on a podcast card in the Library
+/// - Gear button in the podcast detail (EpisodeListView) toolbar
+@MainActor
+public struct PodcastCustomSettingsView: View {
+    @StateObject private var viewModel: PodcastCustomSettingsViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showResetConfirmation = false
+
+    public init(podcast: Podcast, settingsManager: SettingsManager) {
+        _viewModel = StateObject(
+            wrappedValue: PodcastCustomSettingsViewModel(
+                podcast: podcast,
+                settingsManager: settingsManager
+            )
+        )
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Download Settings")) {
+                    Text("Custom download settings coming in a future update.")
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("PodcastCustomSettings.DownloadPlaceholder")
+                }
+
+                Section(header: Text("Retention Settings")) {
+                    Text("Custom retention settings coming in a future update.")
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("PodcastCustomSettings.RetentionPlaceholder")
+                }
+
+                Section(header: Text("Playback Settings")) {
+                    Text("Custom playback settings coming in a future update.")
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("PodcastCustomSettings.PlaybackPlaceholder")
+                }
+
+                Section(header: Text("Sort Settings")) {
+                    Text("Custom sort settings coming in a future update.")
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("PodcastCustomSettings.SortPlaceholder")
+                }
+
+                Section(header: Text("Priority Settings")) {
+                    Text("Custom priority settings coming in a future update.")
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("PodcastCustomSettings.PriorityPlaceholder")
+                }
+
+                Section(header: Text("Notification Settings")) {
+                    Text("Custom notification settings coming in a future update.")
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("PodcastCustomSettings.NotificationPlaceholder")
+                }
+
+                if let error = viewModel.resetError {
+                    Section {
+                        Text(error)
+                            .foregroundColor(.red)
+                            .accessibilityIdentifier("PodcastCustomSettings.ErrorMessage")
+                    }
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        showResetConfirmation = true
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if viewModel.isResetting {
+                                ProgressView()
+                                    .padding(.trailing, 8)
+                            }
+                            Text("Reset to Global Defaults")
+                            Spacer()
+                        }
+                    }
+                    .disabled(viewModel.isResetting)
+                    .accessibilityIdentifier("PodcastCustomSettings.ResetButton")
+                }
+            }
+            .navigationTitle(viewModel.podcast.title)
+            .platformNavigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .accessibilityIdentifier("PodcastCustomSettings.DoneButton")
+                }
+            }
+        }
+        .confirmationDialog(
+            "Reset Settings",
+            isPresented: $showResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Reset", role: .destructive) {
+                Task {
+                    await viewModel.resetSettings()?.value
+                    dismiss()
+                }
+            }
+            .accessibilityIdentifier("PodcastCustomSettings.ResetConfirmButton")
+            Button("Cancel", role: .cancel) {}
+                .accessibilityIdentifier("PodcastCustomSettings.ResetCancelButton")
+        } message: {
+            Text(
+                "Reset all custom settings for \(viewModel.podcast.title)? This cannot be undone."
+            )
+        }
+    }
+}

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift
@@ -122,7 +122,7 @@ public struct PodcastCustomSettingsView: View {
                 }
             }
             .accessibilityIdentifier("PodcastCustomSettings.ResetConfirmButton")
-            Button("Cancel", role: .cancel) {}
+            Button("Cancel") { showResetConfirmation = false }
                 .accessibilityIdentifier("PodcastCustomSettings.ResetCancelButton")
         } message: {
             Text(

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsViewModel.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  PodcastCustomSettingsViewModel.swift
+//  LibraryFeature
+//
+//  View model for PodcastCustomSettingsView (Issue #478: [06.5.1]).
+//
+//  Owns the reset logic so it can be unit-tested independently of the SwiftUI view.
+//
+
+import CoreModels
+import Foundation
+import OSLog
+import SettingsDomain
+
+/// View model for per-podcast custom settings.
+///
+/// Owns the "Reset to Global Defaults" logic: nilifying both the download and
+/// playback overrides for the given podcast in `SettingsManager`.
+@MainActor
+final class PodcastCustomSettingsViewModel: ObservableObject {
+    @Published private(set) var isResetting: Bool = false
+    @Published private(set) var resetError: String? = nil
+
+    let podcast: Podcast
+    private let settingsManager: SettingsManager
+    private(set) var resetTask: Task<Void, Never>?
+
+    private static let logger = Logger(
+        subsystem: "us.zig.zpod.library",
+        category: "PodcastCustomSettingsViewModel"
+    )
+
+    init(podcast: Podcast, settingsManager: SettingsManager) {
+        self.podcast = podcast
+        self.settingsManager = settingsManager
+    }
+
+    /// Resets all per-podcast overrides to global defaults.
+    ///
+    /// Nils out download and playback overrides so the podcast falls back to
+    /// the global `SettingsManager` values. Returns the backing `Task` so
+    /// callers (e.g. unit tests) can `await` completion. Returns `nil` if a
+    /// reset is already in flight.
+    @discardableResult
+    func resetSettings() -> Task<Void, Never>? {
+        guard !isResetting else { return nil }
+        isResetting = true
+        resetError = nil
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.performReset()
+        }
+        resetTask = task
+        return task
+    }
+
+    // MARK: - Private
+
+    private func performReset() async {
+        let podcastId = podcast.id
+        Self.logger.debug("Resetting all settings for podcast \(podcastId)")
+        await settingsManager.updatePodcastDownloadSettings(podcastId: podcastId, nil)
+        await settingsManager.updatePodcastPlaybackSettings(podcastId: podcastId, nil)
+        Self.logger.debug("Reset complete for podcast \(podcastId)")
+        isResetting = false
+    }
+}

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsViewModel.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsViewModel.swift
@@ -19,8 +19,8 @@ import SettingsDomain
 ///
 /// - Note: Per-podcast filter/sort preferences (stored in `GlobalFilterPreferences
 ///   .perPodcastPreferences`) will also need to be cleared here once those overrides
-///   are implemented in 06.3.4 / 06.5.2. TODO: [#06.5.2] extend reset to clear
-///   `perPodcastPreferences[podcastId]` when that field is wired.
+///   are implemented in 06.3.4 / 06.5.2.
+// TODO: [Issue #06.5.2] Extend reset to clear `perPodcastPreferences[podcastId]` when that field is wired.
 @MainActor
 final class PodcastCustomSettingsViewModel: ObservableObject {
     @Published private(set) var isResetting: Bool = false

--- a/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsViewModel.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsViewModel.swift
@@ -14,12 +14,16 @@ import SettingsDomain
 
 /// View model for per-podcast custom settings.
 ///
-/// Owns the "Reset to Global Defaults" logic: nilifying both the download and
+/// Owns the "Reset to Global Defaults" logic: nullifying both the download and
 /// playback overrides for the given podcast in `SettingsManager`.
+///
+/// - Note: Per-podcast filter/sort preferences (stored in `GlobalFilterPreferences
+///   .perPodcastPreferences`) will also need to be cleared here once those overrides
+///   are implemented in 06.3.4 / 06.5.2. TODO: [#06.5.2] extend reset to clear
+///   `perPodcastPreferences[podcastId]` when that field is wired.
 @MainActor
 final class PodcastCustomSettingsViewModel: ObservableObject {
     @Published private(set) var isResetting: Bool = false
-    @Published private(set) var resetError: String? = nil
 
     let podcast: Podcast
     private let settingsManager: SettingsManager
@@ -45,7 +49,6 @@ final class PodcastCustomSettingsViewModel: ObservableObject {
     func resetSettings() -> Task<Void, Never>? {
         guard !isResetting else { return nil }
         isResetting = true
-        resetError = nil
         let task = Task { [weak self] in
             guard let self else { return }
             await self.performReset()

--- a/Packages/LibraryFeature/Tests/LibraryFeatureTests/PodcastCustomSettingsViewModelTests.swift
+++ b/Packages/LibraryFeature/Tests/LibraryFeatureTests/PodcastCustomSettingsViewModelTests.swift
@@ -1,0 +1,127 @@
+//
+//  PodcastCustomSettingsViewModelTests.swift
+//  LibraryFeatureTests
+//
+//  Unit tests for PodcastCustomSettingsViewModel (Issue #478: [06.5.1]).
+//
+//  Spec coverage (Given/When/Then):
+//    AC-Reset-1 — Happy path: Reset confirmed removes download + playback overrides
+//    AC-Reset-2 — Re-entrant: A second reset call while one is in-flight is a no-op
+//    AC-Reset-3 — No-op safety: Reset on a podcast with no overrides does not crash
+//    AC-Reset-4 — isResetting is false after reset completes
+//
+
+import XCTest
+@testable import LibraryFeature
+import CoreModels
+import Persistence
+import SettingsDomain
+
+@MainActor
+final class PodcastCustomSettingsViewModelTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeSUT(podcastId: String = "test-podcast-478") -> (
+        vm: PodcastCustomSettingsViewModel,
+        manager: SettingsManager,
+        repository: UserDefaultsSettingsRepository
+    ) {
+        let suiteName = "PodcastCustomSettings-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        let repository = UserDefaultsSettingsRepository(userDefaults: userDefaults)
+        let manager = SettingsManager(repository: repository)
+        let podcast = Podcast(
+            id: podcastId,
+            title: "Test Podcast",
+            author: "Author",
+            description: "Description",
+            artworkURL: nil,
+            feedURL: URL(string: "https://example.com/feed.rss")!,
+            categories: [],
+            episodes: [],
+            isSubscribed: true
+        )
+        let vm = PodcastCustomSettingsViewModel(podcast: podcast, settingsManager: manager)
+        return (vm, manager, repository)
+    }
+
+    // MARK: - AC-Reset-1: Happy path
+
+    func testResetRemovesDownloadAndPlaybackOverrides() async {
+        // Given: a podcast with both download and playback overrides
+        let podcastId = "reset-happy-path-478"
+        let (vm, manager, repository) = makeSUT(podcastId: podcastId)
+
+        let downloadOverride = PodcastDownloadSettings(
+            podcastId: podcastId,
+            autoDownloadEnabled: true,
+            wifiOnly: false,
+            retentionPolicy: .keepLatest(10)
+        )
+        let playbackOverride = PodcastPlaybackSettings(
+            speed: 1.5,
+            introSkipDuration: 30,
+            outroSkipDuration: 60,
+            skipForwardInterval: nil,
+            skipBackwardInterval: nil
+        )
+        await manager.updatePodcastDownloadSettings(podcastId: podcastId, downloadOverride)
+        await manager.updatePodcastPlaybackSettings(podcastId: podcastId, playbackOverride)
+
+        let beforeDownload = await repository.loadPodcastDownloadSettings(podcastId: podcastId)
+        let beforePlayback = await repository.loadPodcastPlaybackSettings(podcastId: podcastId)
+        XCTAssertNotNil(beforeDownload, "Precondition: download override should exist")
+        XCTAssertNotNil(beforePlayback, "Precondition: playback override should exist")
+
+        // When: reset is confirmed
+        await vm.resetSettings()?.value
+
+        // Then: both overrides are removed from the repository
+        let afterDownload = await repository.loadPodcastDownloadSettings(podcastId: podcastId)
+        let afterPlayback = await repository.loadPodcastPlaybackSettings(podcastId: podcastId)
+        XCTAssertNil(afterDownload, "Download override should be nil after reset")
+        XCTAssertNil(afterPlayback, "Playback override should be nil after reset")
+    }
+
+    // MARK: - AC-Reset-2: Re-entrant guard
+
+    func testSecondResetCallWhileInFlightIsIgnored() async {
+        // Given: a view model
+        let (vm, _, _) = makeSUT()
+
+        // When: resetSettings is called twice rapidly
+        let task1 = vm.resetSettings()
+        // isResetting is now true; second call should return nil
+        let task2 = vm.resetSettings()
+
+        await task1?.value
+
+        // Then: second call returns nil (no-op) since a reset is already in flight
+        XCTAssertNil(task2, "Re-entrant reset should return nil while a reset is in flight")
+    }
+
+    // MARK: - AC-Reset-3: No-op safety
+
+    func testResetOnPodcastWithNoOverridesDoesNotCrash() async {
+        // Given: a podcast with no existing overrides
+        let (vm, _, _) = makeSUT()
+
+        // When/Then: reset does not crash and completes normally
+        await vm.resetSettings()?.value
+    }
+
+    // MARK: - AC-Reset-4: isResetting state
+
+    func testIsResettingIsFalseAfterCompletion() async {
+        // Given: a view model
+        let (vm, _, _) = makeSUT()
+
+        // When: reset completes
+        await vm.resetSettings()?.value
+
+        // Then: isResetting is false
+        XCTAssertFalse(vm.isResetting, "isResetting should be false after reset completes")
+    }
+}

--- a/docs/research/podcast-addict-features.md
+++ b/docs/research/podcast-addict-features.md
@@ -1,0 +1,455 @@
+# Podcast Addict — Feature Research
+
+Competitive analysis of [Podcast Addict](https://play.google.com/store/apps/details?id=com.bambuna.podcastaddict) (Android), focusing on priority, sorting, and automated playlist capabilities.
+
+**Research date:** 2026-04-18
+
+---
+
+## 1. Priority System (-10 to +10)
+
+### Configuration
+
+- **Location:** Long-press a podcast > **Custom Settings** > **Podcast Priority**
+- **Range:** Integer values from **-10** (lowest) to **+10** (highest)
+- **Default:** `0` for newly subscribed podcasts
+
+### What Priority Affects
+
+| Area | Behavior |
+|------|----------|
+| **Playlist sorting** | When the playlist is sorted by priority, episodes from higher-priority podcasts are played first. |
+| **Episode ordering within priority** | Within the same priority level, the **oldest unplayed episodes play first** (FIFO within band). |
+| **Download queue** | Higher-priority podcasts' episodes are downloaded before lower-priority ones. |
+| **Podcast list** | The main podcast list can be sorted by priority. |
+| **Automatic playlist** | When auto-playlist adds newly downloaded episodes, higher-priority episodes are queued higher. |
+
+### Key Behaviors
+
+- Priority acts as the **primary sort key**; a secondary sort (usually publication date) breaks ties within the same priority band.
+- Works in conjunction with the **"Alternate by podcast"** playlist mode — priority determines the round-robin order between podcasts.
+- The official Podcast Addict Twitter account confirmed: *"You will be able to sort your playlist by priority so your favorite podcasts are always played first."*
+
+---
+
+## 2. Sorting Capabilities
+
+Podcast Addict offers sorting at multiple levels throughout the app, with the option for per-screen custom sorting modes.
+
+### 2.1 Episode Sorting (within a podcast)
+
+| Sort Option | Direction |
+|-------------|-----------|
+| Publication date | Newest → Oldest / Oldest → Newest |
+| Download date | Newest → Oldest / Oldest → Newest |
+| Duration | Shortest → Longest / Longest → Shortest |
+| Remaining time | Ascending / Descending |
+| File size | Smallest → Largest / Largest → Smallest |
+| Episode name | A → Z / Z → A |
+| Rating | High → Low / Low → High |
+| Custom | Manual drag & drop reorder |
+
+- **Per-podcast custom sorting:** Enable via **Settings > Display > Podcasts > Custom Sorting**. Each podcast screen can have its own unique sorting mode.
+- **Natural sorting:** Properly handles numbered episode titles (e.g., `episode_1, episode_2, episode_10` sort numerically, not lexicographically).
+
+### 2.2 Podcast List Sorting (main screen)
+
+| Sort Option | Notes |
+|-------------|-------|
+| Name / Title | Alphabetical |
+| Priority | By the -10 to +10 priority value |
+| Unread count | Podcasts with more unread episodes first |
+| Last updated | Most recently updated first |
+| Date added | By subscription date |
+| Custom | Manual drag & drop via **"Reorder (Drag & Drop)"** option menu |
+
+To reorder manually: select the **"Custom"** sorting mode, then press **"Reorder"** in the options menu. Drag handles appear on each podcast.
+
+### 2.3 Playlist Sorting
+
+| Sort Option | Notes |
+|-------------|-------|
+| Publication date | New → Old / Old → New |
+| Download date | New → Old / Old → New |
+| Duration | Short → Long / Long → Short |
+| Episode name | Alphabetical |
+| File name | Alphabetical |
+| Priority | Sorts by podcast priority value (-10 to +10) |
+| Custom / Manual | Drag & drop reorder |
+
+#### Special Playlist Sort Modes
+
+- **Alternate by podcast** (added in v3.43): Instead of strict sort order, the playlist round-robins between podcasts. For example, with "Publication date New→Old + Alternate", it plays the newest episode from Podcast A, then the newest from Podcast B, then C, etc., instead of playing all recent episodes from the same podcast consecutively.
+- **Natural sorting** (togglable in **Settings > Playlist > Natural Sorting**): Handles numbered episode names properly in the playlist view.
+
+### 2.4 Playback Order Controls
+
+These complement sorting within the playlist:
+
+| Control | Behavior |
+|---------|----------|
+| **Play from Top** | After current episode finishes, always returns to the first episode in the list. Useful with priority sorting to ensure highest-priority episodes are always played first. |
+| **Shuffle mode** | Randomizes playback order within the playlist. |
+| **Loop / Repeat** | Loops the playlist after all episodes are played. |
+
+---
+
+## 3. Automated Playlist System
+
+This is Podcast Addict's most feature-rich area. The app provides a sophisticated multi-layered system combining automatic episode management, category-based virtual playlists, per-podcast filtering, and intelligent playback controls.
+
+### 3.1 Two Main Playback Modes
+
+#### Playlist Mode (default: **enabled**)
+- **Setting:** Settings > Playlist > Enable Playlist
+- "Add to playlist" buttons appear on all episodes
+- Pressing an episode's PLAY button adds it to the playlist and starts playback
+- Queue is viewable by opening the player screen and **swiping left**
+- Supports manual reordering via drag & drop
+- Shows **total playlist duration** via options menu on the player screen's playlist tab
+
+#### Continuous Playback Mode (default: **disabled**)
+- **Setting:** Settings > Playlist > Continuous Playback
+- Press play on any episode and the app **automatically creates a temporary queue** with all unplayed episodes displayed on the current screen
+- Respects active screen filters — e.g., if you open the "Favorites" screen and press play, only favorite episodes are queued
+- No manual queue management needed; the app handles it dynamically
+
+### 3.2 Category-Based Custom Playlists (v3.42+)
+
+Podcast Addict's approach to "multiple playlists" uses a category/filter system:
+
+- **Access:** Playlists screen > **Custom** tab
+- **Categories** can come from:
+  - RSS feed categories provided by podcast publishers
+  - **User-created categories** (via the toolbar "Category" button)
+- Users can create themed playlists like "News", "Commute", "Work", etc.
+- **Each category has its own independent filter** with these criteria:
+
+| Filter Criterion | Options |
+|------------------|---------|
+| Episode status | Played / Unplayed |
+| Download status | Downloaded / Not downloaded |
+| Favorite status | Favorites only |
+| Publication date | Date range filtering |
+
+- Select a category from the **upper dropdown menu** to listen to only that category's episodes
+- **Auto-transition:** When all unplayed episodes in a category are finished, the app can **automatically switch** to another category or a live radio station
+
+### 3.3 Automatic Playlist Management
+
+#### Automatic Playlist (auto-add)
+- **Setting:** Settings > Playlist > Automatic Playlist
+- Newly downloaded episodes are **automatically added** to the playlist
+- Works with the auto-download feature: new episode publishes → auto-downloads → auto-added to playlist
+- Respects podcast priority: higher-priority podcast episodes are queued above lower-priority ones
+
+#### Automatic Dequeue (auto-remove)
+- **Setting:** Settings > Playlist > Automatic Dequeue
+- Episodes are **automatically removed** from the playlist once fully listened to
+- Reduces manual playlist maintenance
+
+### 3.4 Episode Filtering (per-podcast)
+
+- **Access:** Long-press podcast > Custom Settings > Episode Filter
+- Keyword-based include/exclude rules:
+  - **Comma-separated keywords** = logical AND (all must match)
+  - **New lines** = logical OR (any can match)
+- Filter by:
+  - Episode type
+  - Episode title
+  - Episode duration
+- **Important behavior:** Filters only apply to **newly retrieved content**. To apply retroactively to existing episodes, long-press the podcast and select **"Reset"**.
+
+### 3.5 Automatic Cleanup & Retention
+
+- **Setting:** Settings > Automatic Cleanup
+
+| Cleanup Option | Description |
+|----------------|-------------|
+| Delete after playback | Auto-delete downloaded file after episode is fully played |
+| Delete by age | Auto-delete based on episode publication date |
+| Delete when marked played | Auto-delete when manually marked as played (default: **off**) |
+| Episode retention limit | "Number of downloaded episodes to keep" per podcast |
+
+- All cleanup settings can be **overridden per-podcast** via Custom Settings
+- Cleanup only affects **downloaded files**, not the episode entries themselves
+
+### 3.6 Per-Podcast Custom Settings
+
+All of the following can be customized independently for each podcast (long-press > Custom Settings):
+
+| Setting Category | Customizable Options |
+|------------------|---------------------|
+| **Priority** | -10 to +10 |
+| **Auto download** | Enable/disable per podcast |
+| **Auto deletion** | Override global cleanup rules |
+| **Episode filter** | Include/exclude keyword rules |
+| **Sorting mode** | Custom sort order per podcast |
+| **Player settings** | Playback speed, volume boost, skip silence |
+| **Playlist settings** | Playlist behavior overrides |
+| **Notifications** | Per-podcast notification preferences |
+
+### 3.7 Queue Management Features
+
+| Feature | Description |
+|---------|-------------|
+| **Manual reorder** | Drag & drop episodes in the queue (swipe left on player screen) |
+| **Total duration** | View total remaining playlist time via options menu |
+| **Shuffle** | Randomize playback order |
+| **Play from Top** | Always restart from first episode after current finishes |
+| **Alternate by podcast** | Round-robin between podcasts instead of sequential play |
+
+### 3.8 Additional Features
+
+| Feature | Description |
+|---------|-------------|
+| **Virtual podcasts** | Treat a local folder's contents as a podcast, manageable in playlists |
+| **Audio & video in same playlist** | Mixed media type support |
+| **Bookmarks** | Save specific moments within episodes |
+| **Sleep timer** | Auto-stop playback after a set time |
+| **Variable playback speed** | Per-podcast or global speed adjustment |
+| **Volume boost** | Amplify quiet audio |
+| **Skip silence** | Automatically skip silent segments |
+| **Chapter support** | Navigate by chapter markers |
+| **OPML import/export** | Transfer subscriptions between apps |
+| **Playback statistics** | Track listening history and stats |
+| **Chromecast / Sonos** | Cast playback to external devices |
+| **Android Auto** | In-car playback integration |
+| **Wear OS** | Smartwatch control support |
+
+---
+
+## Sources
+
+- [Podcast Addict FAQ: Playlist / Continuous Playback](https://podcastaddict.com/faq/210)
+- [Podcast Addict FAQ: Custom Settings Per Podcast](https://podcastaddict.com/faq/340)
+- [Podcast Addict FAQ: Custom Sorting Modes](https://podcastaddict.com/faq/530)
+- [Podcast Addict FAQ: Organizing Podcasts](https://podcastaddict.com/faq/330)
+- [Podcast Addict FAQ: Episode Filtering](https://podcastaddict.com/faq/370)
+- [Podcast Addict FAQ: Playlist Order](https://podcastaddict.com/faq/400)
+- [Podcast Addict FAQ: Removing Old Episodes](https://podcastaddict.com/faq/420)
+- [Podcast Addict FAQ: Automatic Cleanup](https://podcastaddict.com/faq/290)
+- [Podcast Addict FAQ: Automatic Downloads](https://podcastaddict.com/faq/280)
+- [Podcast Addict Getting Started Guide](https://podcastaddict.com/getting_started)
+- [Podcast Addict v3.42 Release (Custom Tabs)](https://www.facebook.com/podcastAddict/photos/1301889306546578/)
+- [Podcast Addict v3.43 Release (Alternate Sort)](https://www.facebook.com/podcastAddict/photos/1314495925285916/)
+- [Podcast Addict on X: Priority Sorting](https://x.com/podcastaddict/status/823954695274143745)
+- [Podcast Addict on Google Play](https://play.google.com/store/apps/details?id=com.bambuna.podcastaddict)
+- [Podcast Addict on AlternativeTo](https://alternativeto.net/software/podcast-addict/about/)
+- [CoolBlindTech: Podcast Addict Introduction](https://coolblindtech.com/podcast-addict-for-android-a-quick-introduction/)
+
+---
+
+## 4. Gap Analysis: zpod vs Podcast Addict
+
+Comparison of zpod's current specs and implementation against Podcast Addict's feature set. Each gap describes what zpod would need to add or change to achieve parity.
+
+### 4.1 Priority System
+
+| Aspect | Podcast Addict | zpod Current State | Gap |
+|--------|---------------|-------------------|-----|
+| **Per-podcast priority** | Integer -10 to +10, set per podcast | No per-podcast priority concept exists | **NEW FEATURE** needed: `priority: Int` on Podcast model (-10...+10, default 0) |
+| **Download priority** | Priority affects download queue order | `DownloadPriority` enum with 3 levels: `.low`, `.normal`, `.high` (`DownloadTask.swift`) | **ENHANCE**: Bridge podcast priority → download priority. Current 3-level enum is too coarse; either map ranges (-10...-4 = low, -3...3 = normal, 4...10 = high) or replace with the integer system |
+| **Playlist sort by priority** | Sorts playlist episodes by their podcast's priority value | `EpisodeSortBy` has no `.priority` case (`EpisodeFiltering.swift:6-14`) | **ADD**: New `.priority` case to `EpisodeSortBy` enum and corresponding sort logic in `EpisodeSortService` |
+| **Intra-priority ordering** | Within same priority band, oldest episodes first (FIFO) | N/A | **ADD**: Secondary sort logic — when primary sort is priority, break ties by publication date ascending |
+| **Priority in auto-playlist** | Higher priority podcasts' new downloads queued higher | No automatic playlist feature exists | Depends on auto-playlist feature (see 4.3) |
+
+**Spec changes needed:**
+- New spec for per-podcast priority setting UI and storage
+- Update `EpisodeSortBy` enum to include `.priority` case
+- Update download queue to respect podcast-level priority
+
+### 4.2 Sorting Capabilities
+
+#### Episode Sorting (`EpisodeSortService.swift`, `EpisodeFiltering.swift`)
+
+| Sort Option | Podcast Addict | zpod | Gap |
+|-------------|---------------|------|-----|
+| Publication date (newest/oldest) | Yes | Yes (`.pubDateNewest`, `.pubDateOldest`) | -- |
+| Download date | Yes | No | **ADD** `.downloadDate` case |
+| Duration | Yes (both directions) | Yes (shortest only, `.duration`) | **ADD** `.durationLongest` for reverse direction |
+| Remaining time | Yes | No | **ADD** `.remainingTime` case (requires `duration - playbackPosition`) |
+| File size | Yes | No | **ADD** `.fileSize` case (requires file size on Episode model) |
+| Episode name | Yes (A-Z / Z-A) | Yes (A-Z only, `.title`) | **ADD** `.titleDescending` for reverse direction |
+| Rating | Yes (both directions) | Yes (high→low only, `.rating`) | **ADD** `.ratingAscending` for reverse direction |
+| Date added | Yes | Yes (`.dateAdded`) | -- |
+| Play status | Yes | Yes (`.playStatus`) | -- |
+| Download status | Yes | Yes (`.downloadStatus`) | -- |
+| Custom (drag & drop) | Yes | No | **ADD** manual reorder support |
+| Natural sorting | Yes (ep1, ep2, ep10) | No | **ADD** numeric-aware string comparison |
+| Per-podcast custom sort | Yes (each podcast can have own sort mode) | No | **ADD** per-podcast sort preference storage |
+
+#### Podcast List Sorting
+
+| Sort Option | Podcast Addict | zpod | Gap |
+|-------------|---------------|------|-----|
+| Name | Yes | Unknown (no podcast list sort spec found) | **ADD** podcast list sorting feature |
+| Priority | Yes | No priority system | Depends on 4.1 |
+| Unread count | Yes | No | **ADD** |
+| Last updated | Yes | No | **ADD** |
+| Date added/subscribed | Yes | No | **ADD** |
+| Custom (drag & drop) | Yes | No | **ADD** |
+
+**Spec changes needed:**
+- New spec for podcast list sorting (6 sort modes)
+- Extend `EpisodeSortBy` with missing cases (download date, remaining time, file size, reverse directions)
+- Per-podcast sort override setting
+
+#### Playlist Sorting
+
+| Sort Option | Podcast Addict | zpod | Gap |
+|-------------|---------------|------|-----|
+| Publication date | Yes | Yes (via `EpisodeSortBy`) | -- |
+| Download date | Yes | No | Same gap as episode sorting |
+| Duration | Yes | Yes | -- |
+| Episode name | Yes | Yes (via `PlaylistSortCriteria.titleAscending/Descending`) | -- |
+| File name | Yes | No | Minor — episode name is likely equivalent |
+| Priority | Yes | No | Depends on 4.1 |
+| Custom/Manual | Yes | Yes (drag & drop in `InMemoryPlaylistManager.reorderEpisodes`) | -- |
+| **Alternate by podcast** | Yes (round-robin between podcasts) | No | **ADD**: New playlist sort mode that interleaves episodes from different podcasts |
+| Natural sorting | Yes (toggle) | No | **ADD** |
+
+#### Playback Order Controls
+
+| Control | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| Play from Top | Yes | No | **ADD**: After current episode finishes, restart from first in list |
+| Shuffle | Yes | Yes (`shuffleAllowed` on `Playlist`) | -- |
+| Loop/Repeat | Yes | No | **ADD** |
+
+### 4.3 Automated Playlist System
+
+#### Playback Modes
+
+| Feature | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| Manual Playlist | Yes (add-to-playlist buttons) | Yes (`Playlist` model with `episodeIds`) | -- |
+| Continuous Playback | Yes (auto-queue unread episodes from same podcast on play) | No | **NEW FEATURE**: When pressing play on an episode, auto-create temporary queue of unread episodes from same podcast displayed on screen |
+| Continuous Playback respects screen filters | Yes | N/A | Part of continuous playback feature |
+
+#### Category-Based Virtual Playlists
+
+| Feature | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| Category tabs | Yes (Custom tab with category dropdown) | No — zpod uses rule-based smart playlists instead | **DESIGN DECISION**: zpod's SmartEpisodeListV2 is more powerful than PA's category system. Consider whether to add simple category shortcuts as "quick filters" on top of the existing rules engine, or stay with the rules-only approach |
+| User-created categories | Yes | Partially — smart playlist templates serve a similar role | Templates exist but aren't category-based |
+| Per-category filters (played/downloaded/favorites/date) | Yes | SmartEpisodeListV2 rules cover all these criteria and more | zpod is **ahead** here — 13 rule types with AND/OR/NOT vs PA's 4 simple filters |
+| Auto-transition between categories | Yes (switch to another category or radio when done) | No | **ADD**: "When playlist finishes, play from..." setting |
+
+#### Automatic Episode Management
+
+| Feature | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| **Automatic Playlist** (auto-add downloaded episodes) | Yes (`Settings > Playlist > Automatic Playlist`) | No | **NEW FEATURE**: Setting to auto-add newly downloaded episodes to a designated playlist |
+| **Automatic Dequeue** (auto-remove after playing) | Yes (`Settings > Playlist > Automatic Dequeue`) | No | **NEW FEATURE**: Setting to auto-remove episodes from playlist after fully played |
+| **Automatic Cleanup** (delete files after play) | Yes (multiple options) | No automatic cleanup spec found | **NEW FEATURE**: Auto-delete downloaded files after playback, by age, or by retention limit |
+| **Episode retention limit** (keep N downloaded per podcast) | Yes (per-podcast override) | No | **ADD** to per-podcast settings |
+
+#### Episode Filtering (per-podcast)
+
+| Feature | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| Keyword include/exclude | Yes (AND via comma, OR via newline) | zpod's `SmartListRuleType.title` and `.description` with `.contains`/`.notContains` | zpod's rule system is more structured; PA's keyword approach is simpler for users |
+| Filter by episode type | Yes | No explicit episode type filter | **ADD** if zpod has an episode type field |
+| Filter by duration | Yes | Yes (via smart list rules) | -- |
+| Retroactive filter reset | Yes (long-press > Reset to reapply) | No equivalent | **ADD** if implementing per-podcast keyword filters |
+
+#### Queue Management
+
+| Feature | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| Manual reorder (drag & drop) | Yes | Yes (`reorderEpisodes` in playlist manager) | -- |
+| Total playlist duration | Yes (options menu) | No | **ADD**: Compute and display sum of episode durations in playlist |
+| Queue view (swipe left on player) | Yes | No spec for queue access gesture | **ADD** to player UI spec |
+
+#### Per-Podcast Custom Settings
+
+| Feature | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| Priority override | Yes (-10 to +10) | No | See 4.1 |
+| Auto-download per podcast | Yes | Unclear — `AutoDownloadService.swift` exists but per-podcast override not confirmed | **VERIFY** and add if missing |
+| Auto-deletion per podcast | Yes | No | **ADD** |
+| Episode filter per podcast | Yes | No per-podcast filter spec | **ADD** |
+| Sort mode per podcast | Yes | No | **ADD** |
+| Player settings per podcast | Yes (speed, volume, skip silence) | No spec for per-podcast playback settings | **ADD** |
+| Playlist settings per podcast | Yes | No | **ADD** |
+| Notification settings per podcast | Yes | No | **ADD** |
+
+#### Additional Features
+
+| Feature | Podcast Addict | zpod | Gap |
+|---------|---------------|------|-----|
+| Virtual podcasts (local folder as podcast) | Yes | No | **NEW FEATURE** (lower priority) |
+| Mixed audio & video playlist | Yes | No video support | N/A — zpod is audio-focused |
+| Bookmarks | Yes | Yes (`.isBookmarked` rule type exists) | -- |
+| Sleep timer | Yes | Exists (referenced in playback settings) | -- |
+| Variable playback speed | Yes | Yes | -- |
+| Skip silence | Yes | Unclear | **VERIFY** |
+| Chapter support | Yes | Unclear | **VERIFY** |
+| OPML import/export | Yes | Import exists (`spec/settings.md`), export exists | -- |
+| Playback statistics | Yes | Unclear | **VERIFY** |
+
+---
+
+## 5. Recommended Spec Changes (Priority Order)
+
+### P0 — High Impact, Core Differentiators
+
+1. **Per-Podcast Priority System** (`NEW SPEC`)
+   - Add `priority: Int` (-10...+10) to Podcast model
+   - Add UI for setting priority (long-press or podcast settings)
+   - Add `.priority` case to `EpisodeSortBy`
+   - Wire priority into download queue ordering
+   - Files to modify: `EpisodeFiltering.swift`, `EpisodeSortService.swift`, `DownloadTask.swift`, Podcast model
+
+2. **Automatic Playlist Management** (`NEW SPEC`)
+   - Auto-add newly downloaded episodes to playlist
+   - Auto-remove episodes from playlist after fully played
+   - Settings toggles for both behaviors
+   - Priority-aware insertion order
+
+3. **Alternate-by-Podcast Sort Mode** (`UPDATE spec/06.1.2`)
+   - Round-robin interleaving of episodes from different podcasts in playlist
+   - Prevents one prolific podcast from dominating the queue
+
+### P1 — Important Enhancements
+
+4. **Extended Sort Options** (`UPDATE EpisodeSortBy`)
+   - Add: download date, remaining time, file size, reverse directions for duration/title/rating
+   - Add: natural sorting for numbered episode titles
+
+5. **Podcast List Sorting** (`NEW SPEC`)
+   - Sort the main podcast list by: name, priority, unread count, last updated, date added, custom
+
+6. **Continuous Playback Mode** (`NEW SPEC`)
+   - Press play on episode → auto-queue all unread episodes from same podcast
+   - Respects active screen filters
+   - Toggle in Settings > Playlist
+
+7. **Automatic Cleanup & Retention** (`NEW SPEC`)
+   - Delete downloaded files after playback
+   - Delete by age (publication date threshold)
+   - Episode retention limit per podcast (keep N downloaded)
+
+### P2 — Nice-to-Have Enhancements
+
+8. **Per-Podcast Custom Settings System** (`NEW SPEC`)
+   - Override auto-download, auto-delete, sort mode, playback speed, episode filter per podcast
+   - Long-press > Custom Settings UI
+
+9. **Playback Order Controls** (`UPDATE player spec`)
+   - Play from Top (always restart from first episode)
+   - Loop/Repeat mode
+
+10. **Auto-Transition** (`NEW SPEC`)
+    - When playlist/category finishes, auto-switch to another playlist or stop
+
+11. **Total Playlist Duration Display** (`UPDATE playlist UI spec`)
+    - Sum and display total remaining time in playlist view
+
+### Where zpod Is Already Ahead
+
+- **Smart playlist rules engine**: zpod's 13 rule types with AND/OR/NOT logic and negation is significantly more powerful than Podcast Addict's simple 4-criterion category filters
+- **Rule templates**: zpod has built-in templates for common scenarios
+- **Live preview**: zpod spec includes live preview of matching episodes during rule creation
+- **Duplicating playlists**: zpod supports duplicating smart playlists with independent editing

--- a/scripts/test-manifest.json
+++ b/scripts/test-manifest.json
@@ -4,12 +4,22 @@
     "Packages/LibraryFeature/Sources/LibraryFeature/ContentView.swift": [
       "Packages",
       "zpodUITests/LibraryViewUITests",
-      "zpodUITests/ContentDiscoveryUITests"
+      "zpodUITests/ContentDiscoveryUITests",
+      "zpodUITests/PodcastCustomSettingsUITests"
     ],
     "Packages/LibraryFeature/Sources/LibraryFeature/EpisodeListView.swift": [
       "EpisodeListUITests",
       "PlayerOrientationSnapshotTests",
-      "SwipeExecutionTests"
+      "SwipeExecutionTests",
+      "zpodUITests/PodcastCustomSettingsUITests"
+    ],
+    "Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsView.swift": [
+      "Packages",
+      "zpodUITests/PodcastCustomSettingsUITests"
+    ],
+    "Packages/LibraryFeature/Sources/LibraryFeature/PodcastCustomSettingsViewModel.swift": [
+      "Packages",
+      "zpodUITests/PodcastCustomSettingsUITests"
     ],
     "Packages/PlaylistFeature/Sources/PlaylistFeature/SmartPlaylistViews.swift": [
       "Packages",

--- a/spec/06.1.2-smart-playlists-automation.md
+++ b/spec/06.1.2-smart-playlists-automation.md
@@ -52,6 +52,8 @@ The implementation builds on the existing `SmartEpisodeListV2` engine (13 rule t
 **And** these lists cannot be deleted or edited
 **And** each list shows the current episode count
 
+> **Note — code mismatch**: The current implementation (`SmartEpisodeListRules.swift`) defines a different set of 6 built-ins ("Downloaded Interviews", "Continue Listening", "Highly Rated", "Long Unplayed", "Quick Episodes", "Recent Unplayed"). This spec is the source of truth; the code must be updated in a follow-on task. "Continue Listening" (in-progress episodes) is available as a user-creatable template (see Scenario 7).
+
 ---
 
 ## Scenario 5: Smart Playlist Detail View
@@ -61,6 +63,7 @@ The implementation builds on the existing `SmartEpisodeListV2` engine (13 rule t
 **Then** I see dynamically evaluated episodes matching the playlist's rules
 **And** I see "Play All" and "Shuffle" buttons
 **And** I see a "Rules" section summarizing the active rules, sort order, and limits
+**And** I see the **total duration** of all matching episodes displayed in the detail header (e.g., "12 episodes · 4h 22m")
 **And** if no episodes match, an empty state explains the situation
 
 ---
@@ -96,7 +99,7 @@ The implementation builds on the existing `SmartEpisodeListV2` engine (13 rule t
 ## Scenario 9: Rule Types and Comparisons
 
 **Given** I am adding rules to a smart playlist
-**Then** I can use any of these 13 rule types:
+**Then** I can use any of these 14 rule types:
   - Play Status (unplayed, played, in-progress)
   - Download Status (downloaded, not downloaded, downloading, failed, queued)
   - Date Added (relative: today, last 3 days, last 7 days, last 30 days, last 90 days)
@@ -110,7 +113,10 @@ The implementation builds on the existing `SmartEpisodeListV2` engine (13 rule t
   - Is Bookmarked (boolean)
   - Is Archived (boolean)
   - Playback Position (progress percentage)
+  - **Podcast Priority** (integer -10 to +10, with greater than / less than / equals comparisons — e.g., "priority >= 5" to include only high-priority podcasts)
 **And** each rule type supports appropriate comparisons (equals, not equals, contains, greater than, less than, etc.)
+
+> **Dependency**: The Podcast Priority rule type requires the per-podcast priority system defined in `spec/06.2-per-podcast-priority.md`.
 
 ---
 

--- a/spec/06.1.3-playlist-automation-behaviors.md
+++ b/spec/06.1.3-playlist-automation-behaviors.md
@@ -1,0 +1,129 @@
+# Spec: 06.1.3 Playlist Automation Behaviors
+
+## Overview
+
+Playlist automation behaviors control **how a playlist operates during playback and in the background** — independent of what episodes are in the list. These are orthogonal to the rules engine (spec 06.1.2) and can apply to both manual playlists and smart playlists.
+
+All automation settings default to **off** for all users. On upgrade from an earlier version, all new toggles default to off and all existing playlists gain new fields with their default values. No existing behavior changes on upgrade.
+
+---
+
+## Scenario 1: Automatic Playlist (Auto-Add)
+
+**Given** I navigate to Settings > Playlist
+**When** I enable "Automatic Playlist"
+**Then** every newly downloaded episode is automatically added to the active playlist
+**And** the insertion position respects podcast priority (spec 06.2) — episodes from higher-priority podcasts are inserted above episodes from lower-priority podcasts
+**And** within the same priority level, newer episodes are inserted above older ones
+**And** if I disable "Automatic Playlist", new downloads are no longer auto-added (existing episodes remain in the playlist)
+
+**Default:** off
+
+---
+
+## Scenario 2: Automatic Dequeue
+
+**Given** I navigate to Settings > Playlist
+**When** I enable "Automatic Dequeue"
+**Then** an episode is automatically removed from the playlist immediately after it has been fully played
+**And** "fully played" means the episode has been marked as played (either by completing playback or by the auto-mark threshold in spec 06.4 Scenario 5)
+**And** if I disable "Automatic Dequeue", episodes remain in the playlist after playing
+
+**Default:** off
+
+---
+
+## Scenario 3: Continuous Playback Mode
+
+**Given** I navigate to Settings > Playlist
+**When** I enable "Continuous Playback"
+**Then** pressing Play on any episode in a single-podcast episode list automatically queues **all unplayed episodes from that podcast** drawn from the **full filtered episode list** for that podcast (not limited to the visible scroll viewport)
+**And** the episode I tapped plays first; remaining unplayed episodes are appended in the current sort order
+**And** when I am viewing a smart playlist that spans multiple podcasts and tap Play on an episode, Continuous Playback queues all unplayed episodes from **that episode's podcast only** (the smart playlist filter is ignored for queue construction)
+**And** if Continuous Playback is off, pressing Play on an episode plays only that single episode
+
+**Default:** off
+
+---
+
+## Scenario 4: Interleave Mode (Alternate-by-Podcast)
+
+**Given** I am viewing a playlist (manual or smart) with episodes from multiple podcasts
+**When** I open the sort/options menu and enable "Interleave by Podcast"
+**Then** after the primary sort is applied, episodes are redistributed round-robin by podcast — one episode per podcast per cycle
+**And** the primary sort determines which episode from each podcast appears in each cycle
+  - Example: Sort by publication date (newest first) + Interleave ON → newest from Podcast A, newest from Podcast B, newest from Podcast C, second-newest from A, second-newest from B, ...
+**And** "Interleave by Podcast" is a separate toggle from the sort order — any primary sort can be combined with interleaving
+**And** if a podcast runs out of episodes, the remaining podcasts continue cycling without it
+**And** if all podcasts have only one episode remaining, interleaving has no visible effect
+
+> **Implementation note**: Interleaving is a post-sort transformation applied to the full episode list. It is NOT a new `EpisodeSortBy` case, because it requires global list context (per-podcast cursors), not pairwise episode comparison.
+
+**Default:** off (per playlist, not global)
+
+---
+
+## Scenario 5: Playback Order Controls
+
+**Given** I am viewing the playlist tab in the player screen
+**When** I tap the options menu
+**Then** I see "Play from Top" and "Loop" toggles
+
+**Play from Top behavior:**
+**Given** "Play from Top" is enabled
+**When** the last episode in the playlist finishes playing
+**Then** playback restarts at position 1 of the playlist and plays through once
+**And** "Play from Top" does NOT restart playback after every individual episode — it fires only when the playlist reaches its end (distinguishing it from Loop)
+
+**Loop/Repeat behavior:**
+**Given** "Loop" is enabled
+**When** the last episode in the playlist finishes playing
+**Then** playback restarts at position 1 and continues looping indefinitely until manually stopped or Loop is disabled
+
+**Mutual exclusivity:**
+**Given** both "Play from Top" and "Loop" are shown
+**Then** enabling one automatically disables the other — they are mutually exclusive
+
+**Default:** both off
+
+---
+
+## Scenario 6: Auto-Transition (When Playlist Finishes)
+
+**Given** I am on a playlist detail screen
+**When** I tap "When Finished" in the playlist settings
+**Then** I can choose: another playlist from my library, or "Stop"
+
+**Given** the playlist finishes playing and a next playlist is configured
+**When** the last episode completes
+**Then** the app immediately begins playing the configured next playlist starting from its first episode (or first unplayed episode if the playlist has a "Continuous Playback" or "Auto-Add" configuration that leaves played episodes in it)
+
+**Given** the configured next playlist is empty
+**When** the transition would occur
+**Then** the app stops playback and displays a notification: "[Playlist name] is empty — playback stopped"
+**And** the app does NOT chain to any further playlist to prevent infinite loops
+
+**Default:** "Stop" (no auto-transition)
+
+---
+
+## Scenario 7: Total Playlist Duration
+
+**Given** I am viewing any playlist detail screen (manual or smart)
+**Then** the header displays the total duration of all episodes in the playlist (e.g., "8 episodes · 3h 14m")
+**And** if any episodes have unknown duration, the display shows "~3h 14m" to indicate an estimate
+**And** the duration updates immediately when episodes are added to or removed from the playlist
+
+---
+
+## Test Coverage Mapping
+
+| Scenario | Test File | Notes |
+|----------|-----------|-------|
+| 1 (Auto-Add) | PlaylistAutomationTests | priority ordering, new download trigger |
+| 2 (Auto-Dequeue) | PlaylistAutomationTests | played trigger, toggle off behavior |
+| 3 (Continuous Playback) | PlaylistAutomationTests | single-podcast queue, smart playlist case |
+| 4 (Interleave Mode) | PlaylistInterleaveTests | round-robin correctness, exhausted podcast case |
+| 5 (Playback Order) | PlaylistPlaybackOrderTests | Play from Top, Loop, mutual exclusivity |
+| 6 (Auto-Transition) | PlaylistTransitionTests | empty next playlist, stop behavior |
+| 7 (Total Duration) | PlaylistDurationTests | unknown duration estimate, live update |

--- a/spec/06.2-per-podcast-priority.md
+++ b/spec/06.2-per-podcast-priority.md
@@ -1,0 +1,105 @@
+# Spec: 06.2 Per-Podcast Priority
+
+## Overview
+
+Every podcast can be assigned a priority from **-10 to +10** (integer, default 0). Priority influences download queue ordering, playlist sort order, and smart playlist filtering. It is stored in per-podcast settings alongside other overrides (`PodcastDownloadSettings`, `PodcastPlaybackSettings`) — the `Podcast` model itself remains lean.
+
+**UI orientation labels** (displayed alongside the slider/stepper — not discrete steps):
+- -10 = "Lowest"
+- -5 = "Low"
+- 0 = "Default"
+- +5 = "High"
+- +10 = "Highest"
+
+The full integer range (-10 through +10) is always available; labels are reference guides only.
+
+On upgrade, all existing podcasts receive priority 0 (Default). No existing behavior changes.
+
+---
+
+## Scenario 1: Set Priority for a Podcast
+
+**Given** I long-press a podcast in the library (or navigate to podcast detail > Settings)
+**When** I select "Custom Settings"
+**Then** I see a "Priority" setting with a slider or stepper spanning -10 to +10
+**And** the current value is shown numerically alongside the orientation label (e.g., "5 — High")
+**And** tapping Save persists the value
+**And** the priority takes effect immediately for downloads and playlist ordering
+
+**Default:** 0 for all podcasts (including newly subscribed podcasts)
+
+---
+
+## Scenario 2: Priority Affects Download Queue Order
+
+**Given** multiple podcasts have auto-download enabled with different priorities
+**When** new episodes are available for download across multiple podcasts simultaneously
+**Then** episodes from the highest-priority podcast are downloaded first
+**And** within the same priority level, download order is determined by episode publication date (oldest first — FIFO)
+**And** episodes from priority -10 podcasts are downloaded last (after all higher-priority episodes)
+**And** if two episodes from different podcasts share the same priority, publication date (oldest first) is the tiebreaker
+
+> **Code note**: `AutoDownloadService.calculateAutoPriority()` currently returns a hardcoded value of 3. This method must be updated to read the stored per-podcast priority from `SettingsRepository`. `DownloadQueueManager.reorderQueue()` must be extended or a priority-aware queue sort added.
+
+---
+
+## Scenario 3: Priority as a Playlist Sort Option
+
+**Given** I am on a playlist detail screen (manual or smart)
+**When** I open the sort picker and select "Priority"
+**Then** episodes are sorted with highest-priority podcast episodes first
+**And** within the same priority level, episodes are sorted oldest-first by publication date (FIFO)
+**And** episodes from podcasts with priority 0 (Default) appear between positive-priority and negative-priority podcasts
+**And** a secondary sort badge shows "Priority · Oldest First within band"
+
+---
+
+## Scenario 4: Priority as a Smart Playlist Rule
+
+**Given** I am adding rules to a smart playlist (spec 06.1.2 Scenario 9)
+**When** I select rule type "Podcast Priority"
+**Then** I can use comparisons: is, is not, is greater than, is less than
+**And** the value picker accepts integers from -10 to +10 with orientation labels
+**And** examples of valid rules:
+  - "Podcast Priority is greater than 4" — matches only high-priority podcasts' episodes
+  - "Podcast Priority is less than 0" — matches only below-default podcasts' episodes
+  - "Podcast Priority is not 0" — matches all non-default-priority podcasts' episodes
+
+---
+
+## Scenario 5: Podcast List Sorted by Priority
+
+**Given** I am on the main library podcast list screen
+**When** I open the sort picker and select "Priority"
+**Then** podcasts are sorted with highest priority at the top
+**And** podcasts with the same priority are sorted alphabetically by title as a tiebreaker
+**And** the sort picker also includes: Name (A-Z), Unread Count, Last Updated, Date Added, Custom (drag-drop)
+
+> **Code note**: This requires a new `PodcastSortBy` enum (see spec 06.3). The library podcast list view must be updated to use this sort.
+
+---
+
+## Scenario 6: Priority Visible in Podcast Views
+
+**Given** a podcast has a non-default priority (anything other than 0)
+**When** I view the library podcast list
+**Then** a subtle priority indicator is visible on that podcast's row (e.g., a small "↑5" or "↓3" badge)
+
+**Given** I open a podcast's detail screen
+**Then** the current priority value is displayed in the podcast info section
+
+**Given** a podcast has priority 0 (Default)
+**Then** no priority indicator is shown (zero is the absence of customization, not a value to display)
+
+---
+
+## Test Coverage Mapping
+
+| Scenario | Test File | Notes |
+|----------|-----------|-------|
+| 1 (Set Priority) | PodcastPriorityTests | storage, default value, UI persistence |
+| 2 (Download Order) | DownloadPriorityTests | queue ordering, FIFO tiebreaker |
+| 3 (Playlist Sort) | EpisodeSortServiceTests | priority sort, FIFO within band |
+| 4 (Smart Rule) | SmartListRuleEvaluatorTests | priority comparisons |
+| 5 (Podcast List Sort) | PodcastSortTests | priority sort, alpha tiebreaker |
+| 6 (Visibility) | PodcastPriorityUITests | badge display, zero = hidden |

--- a/spec/06.3-extended-sorting.md
+++ b/spec/06.3-extended-sorting.md
@@ -1,0 +1,143 @@
+# Spec: 06.3 Extended Sorting
+
+## Overview
+
+Extends zpod's sorting capabilities in three areas:
+1. **Episode sort direction** — adds ascending/descending to all `EpisodeSortBy` cases
+2. **New episode sort options** — download date, remaining time, file size, natural sorting
+3. **Podcast list sorting** — a new `PodcastSortBy` system for the main library screen
+
+Existing sorts are not broken; direction defaults to the current behavior (e.g., publication date defaults to descending/newest-first).
+
+---
+
+## Part 1: Episode Sort Direction
+
+### Scenario 1: Sort Direction Toggle
+
+**Given** I am on any episode list with a sort picker visible
+**When** I select a sort option (e.g., "Duration")
+**Then** I can toggle the direction between ascending and descending
+**And** the direction toggle is displayed as an arrow or "↑ A→Z" / "↓ Z→A" label adjacent to the sort name
+**And** the selected direction is persisted per-screen (global) or per-podcast (when per-podcast sort is configured)
+
+**Default directions for each sort:**
+| Sort | Default direction |
+|------|------------------|
+| Publication Date | Descending (newest first) |
+| Date Added | Descending (newest first) |
+| Download Date | Descending (most recently downloaded first) |
+| Duration | Ascending (shortest first) |
+| Title | Ascending (A → Z) |
+| Rating | Descending (highest rated first) |
+| Play Status | Ascending (unplayed, in-progress, played) |
+| Download Status | Ascending (downloaded first) |
+| Remaining Time | Ascending (least remaining first) |
+| File Size | Ascending (smallest first) |
+| Priority | Descending (highest priority first) |
+
+> **Code note**: The current `EpisodeSortBy` enum has 8 cases. The direction toggle is implemented as an `ascending: Bool` parameter on `EpisodeSortBy` or as a separate `SortDirection` enum paired with it — rather than adding duplicate reverse-direction cases (e.g., no `.durationLongest` case). This keeps the enum at 10–11 cases total (adding download date, remaining time, file size) rather than 20+.
+
+---
+
+## Part 2: New Episode Sort Options
+
+### Scenario 2: Sort by Download Date
+
+**Given** I open the sort picker on any episode list
+**When** I select "Download Date"
+**Then** episodes are sorted by the date/time their download completed
+**And** episodes that have not been downloaded appear at the bottom (not-downloaded episodes have no download date)
+**And** the sort can be toggled ascending (oldest download first) or descending (most recently downloaded first)
+
+---
+
+### Scenario 3: Sort by Remaining Time
+
+**Given** I open the sort picker on any episode list
+**When** I select "Remaining Time"
+**Then** episodes are sorted by their remaining playback time, calculated as `duration - playbackPosition`
+**And** fully unplayed episodes use their full duration as remaining time
+**And** fully played episodes (remaining = 0) appear at the bottom when sorting ascending
+**And** episodes with unknown duration appear after episodes with known duration in either direction
+**And** the ascending direction shows "shortest remaining first" (episodes I can finish soon)
+
+---
+
+### Scenario 4: Sort by File Size
+
+**Given** I open the sort picker on any episode list
+**When** I select "File Size"
+**Then** episodes are sorted by their downloaded file size in bytes
+**And** episodes that are not downloaded appear at the bottom (no file size available)
+**And** the ascending direction shows smallest files first
+
+> **Prerequisite**: This sort requires `fileSize: Int64?` to be added to the `Episode` model. This is a core model change with ripple effects on persistence (SwiftData entity), serialization (Codable), and all tests that construct `Episode` instances. `fileSize` must be populated when a download completes and stored alongside the episode record. This prerequisite must be implemented before file size sorting is available.
+
+---
+
+### Scenario 5: Natural Sorting for Numbered Titles
+
+**Given** a podcast has episodes with numbered titles (e.g., "Episode 1", "Episode 2", "Episode 10", "Episode 11")
+**When** episodes are sorted by Title
+**Then** episodes are sorted using natural sort order: 1, 2, 10, 11 (not lexicographic: 1, 10, 11, 2)
+**And** natural sorting applies to both ascending and descending title sorts
+**And** natural sorting is the default behavior for title sort (not a separate option)
+
+---
+
+## Part 3: Podcast List Sorting
+
+### Scenario 6: Sort the Library Podcast List
+
+**Given** I am on the main library screen showing my subscribed podcasts
+**When** I open the sort picker
+**Then** I can choose from these sort options:
+  - **Name** (A-Z) — alphabetical by podcast title
+  - **Priority** (Highest First) — by per-podcast priority (spec 06.2), alphabetical tiebreaker
+  - **Unread Count** (Most Unread First) — by number of unplayed episodes
+  - **Last Updated** (Most Recent First) — by the date of the most recently published episode
+  - **Date Added** (Newest Subscription First) — by when the podcast was added to the library
+  - **Custom** — manual order via drag-drop reorder
+**And** the selected sort persists across app launches
+**And** the default sort is **Name (A-Z)**
+
+---
+
+### Scenario 7: Custom Podcast Order (Drag-Drop)
+
+**Given** I select "Custom" sort for the podcast list
+**When** the list is in custom order mode
+**Then** a drag handle appears on each podcast row
+**And** I can drag podcasts to any position
+**And** the custom order persists across app launches and feed refreshes
+**And** newly subscribed podcasts are appended to the bottom of the custom order
+
+---
+
+## Part 4: Per-Podcast Sort Override
+
+### Scenario 8: Per-Podcast Episode Sort Override
+
+**Given** I access per-podcast custom settings (spec 06.5 Scenario 1)
+**When** I view the "Episode Sort" setting
+**Then** I see the current sort for this podcast (either the global default or a per-podcast override)
+**And** I can select any `EpisodeSortBy` option with a direction to override the global default for this podcast only
+**And** selecting "Use Global Default" removes the per-podcast override
+
+> **Code note**: Per-podcast sort preferences already exist in `GlobalFilterPreferences.perPodcastPreferences` (a `[String: EpisodeFilter]` dictionary). This scenario formalizes that existing storage as a first-class UI setting. The `EpisodeFilter.sortBy` field already carries the sort; the direction parameter will be added alongside the sort.
+
+---
+
+## Test Coverage Mapping
+
+| Scenario | Test File | Notes |
+|----------|-----------|-------|
+| 1 (Direction Toggle) | EpisodeSortServiceTests | default directions, persistence |
+| 2 (Download Date) | EpisodeSortServiceTests | not-downloaded at bottom |
+| 3 (Remaining Time) | EpisodeSortServiceTests | played = 0, unknown duration |
+| 4 (File Size) | EpisodeSortServiceTests | not-downloaded at bottom, prerequisite |
+| 5 (Natural Sorting) | EpisodeSortServiceTests | numeric title ordering |
+| 6 (Podcast List Sort) | PodcastSortTests | all 6 options, default |
+| 7 (Custom Order) | PodcastSortTests | drag-drop, new subscription position |
+| 8 (Per-Podcast Override) | EpisodeFilterRepositoryTests | override storage, global default removal |

--- a/spec/06.4-automatic-episode-management.md
+++ b/spec/06.4-automatic-episode-management.md
@@ -1,0 +1,102 @@
+# Spec: 06.4 Automatic Episode Management
+
+## Overview
+
+Automatic episode management covers cleanup, retention, and auto-marking behaviors that keep the library from growing indefinitely. Most of the underlying model infrastructure already exists (`RetentionPolicy`, `PodcastDownloadSettings`, `DownloadSettings`) — this spec formalizes the **trigger points**, **behavioral contracts**, and a new configurable auto-mark threshold.
+
+All automatic behaviors default to **off** or **keepAll** for new installs. On upgrade, existing users retain their current settings unchanged.
+
+---
+
+## Scenario 1: Auto-Delete After Playback
+
+**Given** I navigate to Settings > Downloads > Retention Policy
+**When** I select "Delete after played"
+**Then** a downloaded episode's audio file is deleted from device storage immediately after the episode is marked as fully played
+**And** the episode record itself is NOT deleted — it remains in the library as a played episode (without a local file)
+**And** this applies globally to all podcasts unless overridden per-podcast (Scenario 4)
+
+**Trigger point:** Fired on the "playback complete" event (same event that marks the episode as played).
+
+**Default:** off (global retention policy defaults to `keepAll`)
+
+---
+
+## Scenario 2: Auto-Delete by Age
+
+**Given** I navigate to Settings > Downloads > Retention Policy
+**When** I select "Delete after X days" and set a number of days (1–365)
+**Then** downloaded episodes older than X days (by publication date) have their audio files deleted
+**And** deletion is triggered on: app launch, and after each feed refresh completes
+**And** episodes actively being played are never deleted mid-playback even if past the age threshold
+**And** the episode record is retained; only the downloaded file is removed
+
+**Default:** off (not selected)
+
+---
+
+## Scenario 3: Keep Only N Downloaded Episodes Per Podcast
+
+**Given** I navigate to Settings > Downloads > Retention Policy
+**When** I select "Keep latest N" and set a count (1–999)
+**Then** after each download completes for a podcast, if that podcast has more than N downloaded episodes, the oldest downloaded episode's file is deleted to bring the count back to N
+**And** "oldest" is determined by publication date (oldest published, not oldest downloaded)
+**And** the episode record is retained; only the downloaded file is removed
+**And** an episode actively being played is never deleted even if it exceeds the limit
+
+**Trigger point:** Fired after each download completes.
+
+**Default:** off (not selected; global default is `keepAll`)
+
+---
+
+## Scenario 4: Per-Podcast Retention Override
+
+**Given** I access per-podcast custom settings (spec 06.5 Scenario 1)
+**When** I view the "Retention" setting
+**Then** I see the current effective policy (either the global default or a per-podcast override)
+**And** I can select any retention policy (keepAll, delete after played, delete after X days, keep latest N) to override the global policy for this podcast only
+**And** the per-podcast override takes precedence over the global setting
+**And** selecting "Use Global Default" removes the per-podcast override
+
+> **Code note**: `PodcastDownloadSettings.retentionPolicy` already stores a per-podcast `RetentionPolicy?`. The `SettingsRepository` already has methods to read/write per-podcast download settings. This scenario formalizes the behavior contract, not the storage.
+
+---
+
+## Scenario 5: Auto-Mark as Played at Completion Threshold
+
+**Given** I navigate to Settings > Playback > Completion Threshold
+**When** I set the threshold (choices: 90%, 95%, 99%)
+**Then** when an episode's playback position reaches or exceeds that percentage of the total episode duration, the episode is automatically marked as played
+**And** the threshold applies to the **raw episode duration** (not adjusted for `introSkipDuration` or `outroSkipDuration`) — a user with a 60-second outro skip who reaches 93% of a 60-minute episode with a 95% threshold does NOT trigger auto-mark
+**And** once auto-marked as played, the episode is not un-marked if the user seeks back to an earlier position
+**And** this threshold also serves as the trigger for Automatic Dequeue (spec 06.1.3 Scenario 2) and Auto-Delete After Playback (Scenario 1 above)
+
+**Default:** 95%
+
+---
+
+## Scenario 6: Cleanup Trigger Points
+
+**Given** any retention policy other than `keepAll` is configured (globally or per-podcast)
+**Then** the cleanup service evaluates and applies the retention policy at these trigger points:
+  1. **App launch** — full sweep of all podcasts against their effective retention policies
+  2. **Feed refresh complete** — sweep of podcasts whose feeds were just refreshed
+  3. **Download complete** — sweep of the podcast whose episode just finished downloading (for `keepLatest(N)`)
+  4. **Playback complete** — delete file for the just-played episode if policy is `deleteAfterPlayed`
+
+**And** cleanup never deletes a file that is currently being downloaded or played
+**And** cleanup operations are performed on a background queue and do not block the UI
+
+---
+
+## Test Coverage Mapping
+
+| Scenario | Test File | Notes |
+|----------|-----------|-------|
+| 1 (Delete After Played) | AutomaticCleanupTests | trigger on playback complete, record retained |
+| 2 (Delete by Age) | AutomaticCleanupTests | age threshold, app launch trigger, active playback guard |
+| 3 (Keep Latest N) | AutomaticCleanupTests | oldest-first deletion, download complete trigger |
+| 4 (Per-Podcast Override) | EpisodeRetentionTests | override precedence, global default restore |
+| 5 (Auto-Mark Threshold) | PlaybackCompletionTests | 90/95/99% options, raw duration, seek-back |
+| 6 (Trigger Points) | AutomaticCleanupTests | all 4 triggers, background execution |

--- a/spec/06.5-per-podcast-settings.md
+++ b/spec/06.5-per-podcast-settings.md
@@ -146,12 +146,12 @@ All per-podcast overrides default to "Use Global Default" for new installs and f
 
 | Scenario | Test File | Notes |
 |----------|-----------|-------|
-| 1 (Access) | PodcastCustomSettingsTests | long-press, detail nav, title display |
-| 2 (Auto-Download) | PodcastCustomSettingsTests | override, restore global |
+| 1 (Access) | PodcastCustomSettingsUITests | long-press, detail nav, title display |
+| 2 (Auto-Download) | PodcastCustomSettingsViewModelTests | override, restore global |
 | 3 (Retention) | EpisodeRetentionTests | all policy options, restore global |
-| 4 (Playback) | PodcastCustomSettingsTests | speed, skip intervals, restore global |
-| 5 (Episode Sort) | EpisodeFilterRepositoryTests | override storage, global default removal |
+| 4 (Playback) | PodcastCustomSettingsViewModelTests | speed, skip intervals, restore global |
+| 5 (Episode Sort) | EpisodeFilterRepositoryTests, PodcastCustomSettingsViewModelTests | override storage, global default removal |
 | 6 (Priority) | PodcastPriorityTests | storage, default value, UI persistence |
-| 7 (Notifications) | PodcastCustomSettingsTests | override, suppress, restore global |
+| 7 (Notifications) | PodcastCustomSettingsViewModelTests | override, suppress, restore global |
 | 8 (Override Indicator) | PodcastCustomSettingsUITests | badge display, tap navigation, zero = hidden |
-| 9 (Reset) | PodcastCustomSettingsTests | full reset, confirmation, partial reset guard |
+| 9 (Reset) | PodcastCustomSettingsUITests, PodcastCustomSettingsViewModelTests | full reset, confirmation, partial reset guard |

--- a/spec/06.5-per-podcast-settings.md
+++ b/spec/06.5-per-podcast-settings.md
@@ -1,0 +1,157 @@
+# Spec: 06.5 Per-Podcast Settings
+
+## Overview
+
+The per-podcast settings screen consolidates all per-podcast customizations into a single, discoverable location. Most of the underlying storage already exists (`PodcastDownloadSettings`, `PodcastPlaybackSettings`, `GlobalFilterPreferences.perPodcastPreferences`) — this spec formalizes the **access pattern**, **unified UI**, and a new notification preference override.
+
+All per-podcast overrides default to "Use Global Default" for new installs and for newly subscribed podcasts. On upgrade, existing per-podcast settings (download, playback) are retained unchanged; new fields (priority, notification) default to global.
+
+---
+
+## Scenario 1: Access Per-Podcast Settings
+
+**Given** I am on the main library screen or a podcast detail screen
+**When** I long-press a podcast row in the library
+**Then** a context menu appears with a "Custom Settings" option
+**And** tapping "Custom Settings" opens the per-podcast settings screen for that podcast
+
+**Given** I am on a podcast detail screen
+**When** I tap the Settings button (gear icon) in the header
+**Then** the per-podcast settings screen opens for that podcast
+
+**And** the per-podcast settings screen title shows the podcast name
+**And** each setting displays its current effective value (either the per-podcast override or the global default)
+
+---
+
+## Scenario 2: Override Auto-Download
+
+**Given** I am on a podcast's per-podcast settings screen
+**When** I view the "Auto-Download" setting
+**Then** I see three options: "Use Global Default", "On", "Off"
+**And** "Use Global Default" is selected by default (for podcasts with no override)
+**And** selecting "On" or "Off" overrides the global auto-download setting for this podcast only
+**And** selecting "Use Global Default" removes any existing override and restores global behavior
+
+> **Code note**: Stored in `PodcastDownloadSettings.autoDownloadEnabled: Bool?` (nil = use global). The `SettingsRepository` already has per-podcast download settings read/write methods.
+
+---
+
+## Scenario 3: Override Retention Policy
+
+**Given** I am on a podcast's per-podcast settings screen
+**When** I view the "Retention" setting
+**Then** I see the current effective retention policy (global default or per-podcast override)
+**And** I can select any retention policy to override the global for this podcast:
+  - Use Global Default
+  - Keep All
+  - Delete After Played
+  - Delete After X Days (with a day count input, 1–365)
+  - Keep Latest N (with a count input, 1–999)
+**And** selecting "Use Global Default" removes the per-podcast override
+
+> **Code note**: Stored in `PodcastDownloadSettings.retentionPolicy: RetentionPolicy?` (nil = use global). All `RetentionPolicy` enum cases already exist.
+
+---
+
+## Scenario 4: Override Playback Speed and Skip Intervals
+
+**Given** I am on a podcast's per-podcast settings screen
+**When** I view the "Playback" section
+**Then** I see overridable controls for:
+  - **Speed**: a picker (0.5×, 0.75×, 1×, 1.25×, 1.5×, 1.75×, 2×) with a "Use Global Default" option
+  - **Intro Skip**: a stepper (0–120 seconds, 5-second increments) with a "Use Global Default" option
+  - **Outro Skip**: a stepper (0–120 seconds, 5-second increments) with a "Use Global Default" option
+  - **Skip Forward**: a stepper (5–60 seconds) with a "Use Global Default" option
+  - **Skip Backward**: a stepper (5–60 seconds) with a "Use Global Default" option
+**And** each control shows the current effective value alongside its "Use Global Default" indicator
+**And** setting any control to a specific value overrides the global for this podcast only
+
+> **Code note**: Stored in `PodcastPlaybackSettings` (already exists). The `SettingsRepository` already has per-podcast playback settings read/write methods.
+
+---
+
+## Scenario 5: Override Episode Sort Order
+
+**Given** I am on a podcast's per-podcast settings screen
+**When** I view the "Episode Sort" setting
+**Then** I see the current sort for this podcast (either the global default or a per-podcast override)
+**And** I can select any `EpisodeSortBy` option with a sort direction (ascending/descending) to override the global default for this podcast only
+**And** selecting "Use Global Default" removes the per-podcast override and restores the global sort for this podcast
+
+> **Code note**: Stored in `GlobalFilterPreferences.perPodcastPreferences[podcastId]` as an `EpisodeFilter`. This scenario formalizes existing storage as a first-class UI setting.
+
+---
+
+## Scenario 6: Set Podcast Priority
+
+**Given** I am on a podcast's per-podcast settings screen
+**When** I view the "Priority" setting
+**Then** I see a slider or stepper spanning -10 to +10
+**And** the current numeric value is shown alongside an orientation label:
+  - -10 = "Lowest", -5 = "Low", 0 = "Default", +5 = "High", +10 = "Highest"
+**And** the full integer range (-10 through +10) is always available; labels are reference guides only
+**And** the default value for all podcasts is 0 (Default)
+**And** tapping Save (or navigating away) persists the priority value immediately
+
+**Default:** 0 for all podcasts
+
+> **Code note**: Stored in `PodcastDownloadSettings.priority: Int` (new field, default 0). See spec 06.2 for how priority affects download queue ordering, playlist sorting, and smart list rules.
+
+---
+
+## Scenario 7: Override Notification Preference
+
+**Given** I am on a podcast's per-podcast settings screen
+**When** I view the "New Episode Notifications" setting
+**Then** I see three options: "Use Global Default", "On", "Off"
+**And** "Use Global Default" is selected by default (for podcasts with no override)
+**And** selecting "On" enables new-episode notifications for this podcast regardless of the global setting
+**And** selecting "Off" suppresses new-episode notifications for this podcast regardless of the global setting
+**And** selecting "Use Global Default" removes any existing override
+
+> **Code note**: New per-podcast notification preference — requires adding a `notificationOverride: Bool?` field (nil = use global) to a new `PodcastNotificationSettings` struct or extending `PodcastDownloadSettings`.
+
+---
+
+## Scenario 8: Override Indicator in Library and Detail
+
+**Given** any per-podcast setting is overriding the global default (i.e., any field is non-nil or non-default)
+**When** I view the main library podcast list
+**Then** a subtle indicator (e.g., a small settings badge or dot) is visible on that podcast's row, adjacent to the podcast title
+**And** tapping the indicator navigates directly to the per-podcast settings screen
+
+**Given** any per-podcast setting is overriding the global default
+**When** I view the podcast detail screen
+**Then** the same indicator appears in the podcast detail header, adjacent to the podcast title
+**And** tapping the indicator navigates directly to the per-podcast settings screen
+
+**Given** all per-podcast settings are at their global defaults (no overrides active)
+**Then** no indicator is shown — the absence of customization should not add visual noise
+
+---
+
+## Scenario 9: Reset All Per-Podcast Settings
+
+**Given** I am on a podcast's per-podcast settings screen
+**When** I tap "Reset to Global Defaults"
+**Then** a confirmation prompt appears: "Reset all custom settings for [Podcast Name]? This cannot be undone."
+**And** confirming the reset removes all per-podcast overrides for this podcast (auto-download, retention, playback, sort, priority, notifications)
+**And** after reset, all settings display "Use Global Default" and the override indicator is removed from the library row and podcast detail header
+**And** cancelling leaves all settings unchanged
+
+---
+
+## Test Coverage Mapping
+
+| Scenario | Test File | Notes |
+|----------|-----------|-------|
+| 1 (Access) | PodcastCustomSettingsTests | long-press, detail nav, title display |
+| 2 (Auto-Download) | PodcastCustomSettingsTests | override, restore global |
+| 3 (Retention) | EpisodeRetentionTests | all policy options, restore global |
+| 4 (Playback) | PodcastCustomSettingsTests | speed, skip intervals, restore global |
+| 5 (Episode Sort) | EpisodeFilterRepositoryTests | override storage, global default removal |
+| 6 (Priority) | PodcastPriorityTests | storage, default value, UI persistence |
+| 7 (Notifications) | PodcastCustomSettingsTests | override, suppress, restore global |
+| 8 (Override Indicator) | PodcastCustomSettingsUITests | badge display, tap navigation, zero = hidden |
+| 9 (Reset) | PodcastCustomSettingsTests | full reset, confirmation, partial reset guard |

--- a/zpodUITests/ContentDiscoveryUITests.swift
+++ b/zpodUITests/ContentDiscoveryUITests.swift
@@ -46,7 +46,7 @@ final class ContentDiscoveryUITests: IsolatedUITestCase {
   private func logDiscoverDiagnostics(_ message: String, app: XCUIApplication, discoverTab: XCUIElement?) {
     guard discoverDiagnosticsEnabled else { return }
     let tabBar = app.tabBars.matching(identifier: "Main Tab Bar").firstMatch
-    let miniPlayer = app.otherElements.matching(identifier: "Mini Player").firstMatch
+    let miniPlayer = app.descendants(matching: .any).matching(identifier: "Mini Player").firstMatch
     let discoverRootOther = app.otherElements.matching(identifier: "Discover.Root").firstMatch
     let discoverRootAny = app.descendants(matching: .any)
       .matching(identifier: "Discover.Root")

--- a/zpodUITests/DownloadFlowUITests.swift
+++ b/zpodUITests/DownloadFlowUITests.swift
@@ -523,24 +523,28 @@ final class DownloadFlowUITests: IsolatedUITestCase {
     )
     libraryTab.tap()
 
-    // Wait for loading to complete
-    guard waitForLoadingToComplete(in: app, timeout: adaptiveTimeout) else {
-      XCTFail("Library content failed to load")
-      return
-    }
-
-    // Find and tap first podcast
+    // Wait directly for a podcast — its appearance confirms loading is complete.
+    // Uses full adaptiveTimeout since library + seeding init can take >10s on loaded CI
+    // runners. Eliminates the two-step timeout-budget problem where
+    // waitForLoadingToComplete consumed the full budget before the podcast search began
+    // (waitForLoadingToComplete already checks for Podcast-swift-talk internally).
     let podcast = waitForAnyElement(
       [
         app.buttons.matching(identifier: "Podcast-swift-talk").firstMatch,
-        app.buttons.matching(NSPredicate(format: "identifier CONTAINS 'Podcast'")).firstMatch,
+        app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH 'Podcast-'")).firstMatch,
       ],
-      timeout: adaptiveShortTimeout,
-      description: "podcast button"
+      timeout: adaptiveTimeout,
+      description: "podcast in library",
+      failOnTimeout: false
     )
 
-    guard let podcast = podcast else {
-      XCTFail("No podcast found to navigate to")
+    guard let podcast else {
+      // Lightweight diagnostics: distinguish "tab didn't load" from "seeded data missing"
+      let navBarExists = app.navigationBars.firstMatch.exists
+      let libraryTabHittable = libraryTab.isHittable
+      XCTFail(
+        "No podcast found in library within \(adaptiveTimeout)s (navBar=\(navBarExists), libraryTab=\(libraryTabHittable))"
+      )
       return
     }
 

--- a/zpodUITests/PlaybackUITests.swift
+++ b/zpodUITests/PlaybackUITests.swift
@@ -852,7 +852,7 @@ extension PlaybackUITests {
   func testMiniPlayerVisibilityAndExpansion() throws {
     startPlaybackFromLibraryQuickPlay()
 
-    let miniPlayer = app.otherElements.matching(identifier: "Mini Player").firstMatch
+    let miniPlayer = app.descendants(matching: .any).matching(identifier: "Mini Player").firstMatch
     XCTAssertTrue(
       miniPlayer.waitForExistence(timeout: adaptiveTimeout),
       "Mini player should appear after playback starts"

--- a/zpodUITests/PodcastCustomSettingsUITests.swift
+++ b/zpodUITests/PodcastCustomSettingsUITests.swift
@@ -1,0 +1,217 @@
+//
+//  PodcastCustomSettingsUITests.swift
+//  zpodUITests
+//
+//  Tests for Issue #478: [06.5.1] PodcastCustomSettingsView scaffolding,
+//  access points, and Reset All.
+//
+//  Spec scenarios covered:
+//  - Given a podcast exists, long-pressing the card shows "Custom Settings…" in context menu
+//  - Given a podcast exists, tapping the gear button in EpisodeListView opens custom settings
+//  - Given the custom settings sheet is open, Reset All button is visible
+//  - Given Reset confirmation dialog appears, cancelling dismisses it without changes
+//  - Given Reset confirmation dialog appears, confirming it completes and dismisses the sheet
+//
+
+import TestSupport
+import XCTest
+
+final class PodcastCustomSettingsUITests: IsolatedUITestCase {
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func navigateToLibrary() {
+        let tabBar = app.tabBars.matching(identifier: "Main Tab Bar").firstMatch
+        XCTAssertTrue(
+            tabBar.waitForExistence(timeout: adaptiveTimeout),
+            "Main tab bar must exist before navigating to Library"
+        )
+        let libraryTab = tabBar.buttons.matching(identifier: "Library").firstMatch
+        XCTAssertTrue(
+            libraryTab.waitForExistence(timeout: adaptiveShortTimeout),
+            "Library tab button must be discoverable"
+        )
+        libraryTab.tap()
+    }
+
+    @MainActor
+    private func openCustomSettingsViaContextMenu() {
+        let podcastCard = app.buttons
+            .matching(identifier: "Podcast-\(PodcastFixtures.swiftTalk.id)")
+            .firstMatch
+        XCTAssertTrue(
+            podcastCard.waitForExistence(timeout: adaptiveTimeout),
+            "Podcast card must exist before long-pressing"
+        )
+        podcastCard.press(forDuration: 1.0)
+
+        let menuItem = app.buttons
+            .matching(identifier: "Podcast-\(PodcastFixtures.swiftTalk.id).CustomSettings")
+            .firstMatch
+        XCTAssertTrue(
+            menuItem.waitForExistence(timeout: adaptiveTimeout),
+            "Custom Settings context menu item must appear after long-press"
+        )
+        menuItem.tap()
+    }
+
+    @MainActor
+    private func openCustomSettingsViaGearButton() {
+        let podcastCard = app.buttons
+            .matching(identifier: "Podcast-\(PodcastFixtures.swiftTalk.id)")
+            .firstMatch
+        XCTAssertTrue(
+            podcastCard.waitForExistence(timeout: adaptiveTimeout),
+            "Podcast card must exist"
+        )
+        podcastCard.tap()
+
+        let gearButton = app.buttons
+            .matching(identifier: "PodcastCustomSettingsButton")
+            .firstMatch
+        XCTAssertTrue(
+            gearButton.waitForExistence(timeout: adaptiveTimeout),
+            "Gear button must appear in podcast detail toolbar"
+        )
+        gearButton.tap()
+    }
+
+    @MainActor
+    private func waitForCustomSettingsSheet() {
+        let resetButton = app.buttons
+            .matching(identifier: "PodcastCustomSettings.ResetButton")
+            .firstMatch
+        XCTAssertTrue(
+            resetButton.waitForExistence(timeout: adaptiveTimeout),
+            "PodcastCustomSettingsView Reset button must appear"
+        )
+    }
+
+    // MARK: - Tests
+
+    // MARK: Access Point: Context Menu
+
+    /// Given: App launched with a seeded podcast
+    /// When:  User long-presses the podcast card in Library
+    /// Then:  "Custom Settings…" context menu item appears
+    @MainActor
+    func testContextMenuShowsCustomSettingsItem() throws {
+        app = launchConfiguredApp()
+        navigateToLibrary()
+
+        let podcastCard = app.buttons
+            .matching(identifier: "Podcast-\(PodcastFixtures.swiftTalk.id)")
+            .firstMatch
+        XCTAssertTrue(
+            podcastCard.waitForExistence(timeout: adaptiveTimeout),
+            "Podcast card must exist in Library"
+        )
+        podcastCard.press(forDuration: 1.0)
+
+        let menuItem = app.buttons
+            .matching(identifier: "Podcast-\(PodcastFixtures.swiftTalk.id).CustomSettings")
+            .firstMatch
+        XCTAssertTrue(
+            menuItem.waitForExistence(timeout: adaptiveTimeout),
+            "Custom Settings context menu item must appear after long-press on podcast card"
+        )
+    }
+
+    /// Given: App launched with a seeded podcast
+    /// When:  User long-presses podcast card and taps "Custom Settings…"
+    /// Then:  PodcastCustomSettingsView opens with Reset button visible
+    @MainActor
+    func testContextMenuOpensCustomSettingsSheet() throws {
+        app = launchConfiguredApp()
+        navigateToLibrary()
+        openCustomSettingsViaContextMenu()
+        waitForCustomSettingsSheet()
+    }
+
+    // MARK: Access Point: Gear Button
+
+    /// Given: App launched with a seeded podcast
+    /// When:  User taps the podcast card then taps the gear button
+    /// Then:  PodcastCustomSettingsView opens with Reset button visible
+    @MainActor
+    func testGearButtonOpensCustomSettingsSheet() throws {
+        app = launchConfiguredApp()
+        navigateToLibrary()
+        openCustomSettingsViaGearButton()
+        waitForCustomSettingsSheet()
+    }
+
+    // MARK: Reset All — Cancel Flow
+
+    /// Given: PodcastCustomSettingsView is open (via context menu)
+    /// When:  User taps "Reset to Global Defaults" then taps "Cancel"
+    /// Then:  Confirmation dialog dismisses; settings sheet remains visible
+    @MainActor
+    func testResetCancelKeepsSheetOpen() throws {
+        app = launchConfiguredApp()
+        navigateToLibrary()
+        openCustomSettingsViaContextMenu()
+        waitForCustomSettingsSheet()
+
+        let resetButton = app.buttons
+            .matching(identifier: "PodcastCustomSettings.ResetButton")
+            .firstMatch
+        resetButton.tap()
+
+        let cancelButton = app.buttons
+            .matching(identifier: "PodcastCustomSettings.ResetCancelButton")
+            .firstMatch
+        XCTAssertTrue(
+            cancelButton.waitForExistence(timeout: adaptiveTimeout),
+            "Cancel button must appear in reset confirmation dialog"
+        )
+        cancelButton.tap()
+
+        // Sheet must remain open after cancel
+        let resetButtonAfterCancel = app.buttons
+            .matching(identifier: "PodcastCustomSettings.ResetButton")
+            .firstMatch
+        XCTAssertTrue(
+            resetButtonAfterCancel.waitForExistence(timeout: adaptiveTimeout),
+            "Custom settings sheet must remain visible after cancelling reset confirmation"
+        )
+    }
+
+    // MARK: Reset All — Happy Path
+
+    /// Given: PodcastCustomSettingsView is open (via gear button)
+    /// When:  User taps "Reset to Global Defaults" then confirms
+    /// Then:  Sheet dismisses (Reset completed successfully)
+    @MainActor
+    func testResetConfirmDismissesSheet() throws {
+        app = launchConfiguredApp()
+        navigateToLibrary()
+        openCustomSettingsViaGearButton()
+        waitForCustomSettingsSheet()
+
+        let resetButton = app.buttons
+            .matching(identifier: "PodcastCustomSettings.ResetButton")
+            .firstMatch
+        resetButton.tap()
+
+        let confirmButton = app.buttons
+            .matching(identifier: "PodcastCustomSettings.ResetConfirmButton")
+            .firstMatch
+        XCTAssertTrue(
+            confirmButton.waitForExistence(timeout: adaptiveTimeout),
+            "Reset confirm button must appear in confirmation dialog"
+        )
+        confirmButton.tap()
+
+        // After confirming reset, the sheet must dismiss — Reset button should disappear
+        let resetButtonAfterConfirm = app.buttons
+            .matching(identifier: "PodcastCustomSettings.ResetButton")
+            .firstMatch
+        let dismissed = resetButtonAfterConfirm.waitForNonExistence(timeout: adaptiveTimeout)
+        XCTAssertTrue(
+            dismissed,
+            "Custom settings sheet must dismiss after confirming reset"
+        )
+    }
+}

--- a/zpodUITests/PodcastCustomSettingsUITests.swift
+++ b/zpodUITests/PodcastCustomSettingsUITests.swift
@@ -159,12 +159,12 @@ final class PodcastCustomSettingsUITests: IsolatedUITestCase {
             .firstMatch
         resetButton.tap()
 
-        let cancelButton = app.buttons
+        let cancelButton = app.alerts.buttons
             .matching(identifier: "PodcastCustomSettings.ResetCancelButton")
             .firstMatch
         XCTAssertTrue(
             cancelButton.waitForExistence(timeout: adaptiveTimeout),
-            "Cancel button must appear in reset confirmation dialog"
+            "Cancel button must appear in reset confirmation alert"
         )
         cancelButton.tap()
 
@@ -195,12 +195,12 @@ final class PodcastCustomSettingsUITests: IsolatedUITestCase {
             .firstMatch
         resetButton.tap()
 
-        let confirmButton = app.buttons
+        let confirmButton = app.alerts.buttons
             .matching(identifier: "PodcastCustomSettings.ResetConfirmButton")
             .firstMatch
         XCTAssertTrue(
             confirmButton.waitForExistence(timeout: adaptiveTimeout),
-            "Reset confirm button must appear in confirmation dialog"
+            "Reset confirm button must appear in confirmation alert"
         )
         confirmButton.tap()
 
@@ -208,9 +208,11 @@ final class PodcastCustomSettingsUITests: IsolatedUITestCase {
         let resetButtonAfterConfirm = app.buttons
             .matching(identifier: "PodcastCustomSettings.ResetButton")
             .firstMatch
-        let dismissed = resetButtonAfterConfirm.waitForNonExistence(timeout: adaptiveTimeout)
-        XCTAssertTrue(
-            dismissed,
+        let notExists = NSPredicate(format: "exists == false")
+        let disappears = XCTNSPredicateExpectation(predicate: notExists, object: resetButtonAfterConfirm)
+        wait(for: [disappears], timeout: adaptiveTimeout)
+        XCTAssertFalse(
+            resetButtonAfterConfirm.exists,
             "Custom settings sheet must dismiss after confirming reset"
         )
     }

--- a/zpodUITests/UITestHelpers.swift
+++ b/zpodUITests/UITestHelpers.swift
@@ -316,7 +316,7 @@ extension ElementWaiting {
   }
 
   func miniPlayerElement(in app: XCUIApplication) -> XCUIElement {
-    app.otherElements.matching(identifier: "Mini Player").firstMatch
+    app.descendants(matching: .any).matching(identifier: "Mini Player").firstMatch
   }
 
   func hasNonEmptyLabel(_ element: XCUIElement) -> Bool {


### PR DESCRIPTION
## Summary

- **Fix 1 — Mini Player type classification race**: `app.otherElements` filters by accessibility type `.other`, but in CI the Mini Player element sometimes resolves as `.progressIndicator`, producing zero matches. Changed to `app.descendants(matching: .any)` in the helper (`UITestHelpers.miniPlayerElement()`) and in two inline accesses that bypass the helper (`PlaybackUITests.swift:855`, `ContentDiscoveryUITests.swift:49`).
- **Fix 2 — `navigateToEpisodeList()` timeout budget split**: `waitForLoadingToComplete()` already checks for `Podcast-swift-talk` internally (UITestHelpers.swift:674), making it redundant. After it consumes the full `adaptiveTimeout` (12s), only `adaptiveShortTimeout` (6s) remains for the podcast search — causing failures when load takes 10–17s. Replaced with a single `waitForAnyElement` using the full timeout. Also tightened the predicate from `CONTAINS 'Podcast'` to `BEGINSWITH 'Podcast-'` and added failure diagnostics.

## Files Changed

| File | Change |
|------|--------|
| `zpodUITests/UITestHelpers.swift` | `miniPlayerElement()`: `otherElements` → `descendants(matching: .any)` |
| `zpodUITests/PlaybackUITests.swift` | Inline mini player query: same fix |
| `zpodUITests/ContentDiscoveryUITests.swift` | Inline mini player query in diagnostic path: same fix |
| `zpodUITests/DownloadFlowUITests.swift` | `navigateToEpisodeList()`: remove redundant `waitForLoadingToComplete`, single direct wait with diagnostics |

## Test plan

- [x] Syntax gate passes (`./scripts/run-xcode-tests.sh -s`)
- [x] `DownloadFlowUITests`: 7/7 pass locally
- [x] `PlaybackUITests`: 18/18 pass locally
- [ ] CI green on push

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)