### PR TITLE
[#471] Sort direction toggle and natural title sort [06.3.1]

### DIFF
--- a/Packages/CoreModels/Sources/CoreModels/EpisodeFilterService.swift
+++ b/Packages/CoreModels/Sources/CoreModels/EpisodeFilterService.swift
@@ -36,17 +36,6 @@ public protocol EpisodeFilterService: Sendable {
     func smartListNeedsUpdate(_ smartList: SmartEpisodeList) -> Bool
 }
 
-// MARK: - Protocol Default Implementations
-
-public extension EpisodeFilterService {
-    /// Default implementation delegates to the existing single-parameter overload.
-    /// Concrete types (e.g. DefaultEpisodeFilterService) override with a real implementation.
-    func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy, ascending: Bool) -> [Episode] {
-        // Fall back to default-direction sort; callers that need direction should use a concrete type.
-        return sortEpisodes(episodes, by: sortBy)
-    }
-}
-
 // MARK: - Default Implementation
 
 /// Default implementation using composable helper services.

--- a/Packages/CoreModels/Sources/CoreModels/EpisodeFilterService.swift
+++ b/Packages/CoreModels/Sources/CoreModels/EpisodeFilterService.swift
@@ -11,9 +11,12 @@ public protocol EpisodeFilterService: Sendable {
     /// Check if episode matches filter condition
     func episodeMatches(_ episode: Episode, condition: EpisodeFilterCondition) -> Bool
     
-    /// Sort episodes by criteria
+    /// Sort episodes by criteria using the sort type's default direction
     func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy) -> [Episode]
-    
+
+    /// Sort episodes by criteria with an explicit direction
+    func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy, ascending: Bool) -> [Episode]
+
     /// Search episodes by text query
     func searchEpisodes(_ episodes: [Episode], query: String, filter: EpisodeFilter?, includeArchived: Bool) -> [Episode]
     
@@ -31,6 +34,17 @@ public protocol EpisodeFilterService: Sendable {
     
     /// Check if smart list needs updating based on refresh interval
     func smartListNeedsUpdate(_ smartList: SmartEpisodeList) -> Bool
+}
+
+// MARK: - Protocol Default Implementations
+
+public extension EpisodeFilterService {
+    /// Default implementation delegates to the existing single-parameter overload.
+    /// Concrete types (e.g. DefaultEpisodeFilterService) override with a real implementation.
+    func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy, ascending: Bool) -> [Episode] {
+        // Fall back to default-direction sort; callers that need direction should use a concrete type.
+        return sortEpisodes(episodes, by: sortBy)
+    }
 }
 
 // MARK: - Default Implementation
@@ -80,15 +94,19 @@ public actor DefaultEpisodeFilterService: EpisodeFilterService {
     
     nonisolated public func filterAndSort(episodes: [Episode], using filter: EpisodeFilter) -> [Episode] {
         let filteredEpisodes = filterEvaluator.applyFilter(episodes, filter: filter)
-        return sortService.sortEpisodes(filteredEpisodes, by: filter.sortBy)
+        return sortService.sortEpisodes(filteredEpisodes, by: filter.sortBy, ascending: filter.effectiveAscending)
     }
-    
+
     nonisolated public func episodeMatches(_ episode: Episode, condition: EpisodeFilterCondition) -> Bool {
         return filterEvaluator.episodeMatches(episode, condition: condition)
     }
-    
+
     nonisolated public func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy) -> [Episode] {
         return sortService.sortEpisodes(episodes, by: sortBy)
+    }
+
+    nonisolated public func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy, ascending: Bool) -> [Episode] {
+        return sortService.sortEpisodes(episodes, by: sortBy, ascending: ascending)
     }
     
     /// Search episodes by text query
@@ -156,7 +174,7 @@ public actor DefaultEpisodeFilterService: EpisodeFilterService {
             smartListRuleEvaluator.evaluateSmartListRules(episode: episode, rules: smartList.rules)
         }
         
-        let sortedEpisodes = sortService.sortEpisodes(filteredEpisodes, by: smartList.sortBy)
+        let sortedEpisodes = sortService.sortEpisodes(filteredEpisodes, by: smartList.sortBy, ascending: smartList.sortBy.defaultAscending)
         
         if let maxEpisodes = smartList.maxEpisodes {
             return Array(sortedEpisodes.prefix(maxEpisodes))

--- a/Packages/CoreModels/Sources/CoreModels/EpisodeFiltering.swift
+++ b/Packages/CoreModels/Sources/CoreModels/EpisodeFiltering.swift
@@ -25,6 +25,21 @@ public enum EpisodeSortBy: String, Codable, Sendable, CaseIterable {
         case .dateAdded: return "Date Added"
         }
     }
+
+    /// Default sort direction for this sort type (true = ascending, false = descending).
+    /// Matches the natural expected ordering per sort type.
+    public var defaultAscending: Bool {
+        switch self {
+        case .pubDateNewest:   return false // newest first = date descending
+        case .pubDateOldest:   return true  // oldest first = date ascending
+        case .duration:        return true  // shortest first
+        case .title:           return true  // A→Z
+        case .playStatus:      return true  // unplayed first
+        case .downloadStatus:  return true  // downloaded first
+        case .rating:          return false // highest first
+        case .dateAdded:       return false // newest added first
+        }
+    }
 }
 
 /// Filter criteria for episodes
@@ -101,17 +116,27 @@ public struct EpisodeFilter: Codable, Equatable, Sendable {
     public let conditions: [EpisodeFilterCondition]
     public let logic: FilterLogic
     public let sortBy: EpisodeSortBy
-    
+    /// Explicit sort direction. `nil` means use `sortBy.defaultAscending`.
+    /// Persisted as an optional JSON key — missing key decodes as `nil` for backward compatibility.
+    public let sortAscending: Bool?
+
     public init(
         conditions: [EpisodeFilterCondition] = [],
         logic: FilterLogic = .and,
-        sortBy: EpisodeSortBy = .pubDateNewest
+        sortBy: EpisodeSortBy = .pubDateNewest,
+        sortAscending: Bool? = nil
     ) {
         self.conditions = conditions
         self.logic = logic
         self.sortBy = sortBy
+        self.sortAscending = sortAscending
     }
-    
+
+    /// Resolved sort direction: uses explicit override if set, otherwise the sort type's default.
+    public var effectiveAscending: Bool {
+        sortAscending ?? sortBy.defaultAscending
+    }
+
     public var isEmpty: Bool {
         return conditions.isEmpty
     }

--- a/Packages/CoreModels/Sources/CoreModels/EpisodeSearchHelper.swift
+++ b/Packages/CoreModels/Sources/CoreModels/EpisodeSearchHelper.swift
@@ -26,7 +26,7 @@ public struct EpisodeSearchHelper: Sendable {
         
         if let filter = filter {
             let filtered = filterEvaluator.applyFilter(searchResults, filter: filter)
-            return sortService.sortEpisodes(filtered, by: filter.sortBy)
+            return sortService.sortEpisodes(filtered, by: filter.sortBy, ascending: filter.effectiveAscending)
         } else {
             // Default sort by relevance (we could implement scoring here)
             return searchResults

--- a/Packages/CoreModels/Sources/CoreModels/EpisodeSortService.swift
+++ b/Packages/CoreModels/Sources/CoreModels/EpisodeSortService.swift
@@ -14,45 +14,55 @@ public struct EpisodeSortService: Sendable {
     }
 
     /// Sort episodes by criteria with an explicit direction.
-    /// Each case sorts in canonical ascending order; `ascending: false` reverses the result.
     /// Nil pubDate/duration values are pushed to the end regardless of direction.
     public func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy, ascending: Bool) -> [Episode] {
-        let sorted: [Episode]
         switch sortBy {
         case .pubDateNewest, .pubDateOldest:
-            // Both cases sort on pubDate; ascending = oldest first, descending = newest first.
-            sorted = episodes.sorted { (lhs, rhs) in
-                guard let lhsDate = lhs.pubDate else { return false } // nil = pushed to end in ascending
+            return episodes.sorted { (lhs, rhs) in
+                // Nil values always sort to the end regardless of direction
+                guard let lhsDate = lhs.pubDate else { return false }
                 guard let rhsDate = rhs.pubDate else { return true }
-                return lhsDate < rhsDate
+                return ascending ? lhsDate < rhsDate : lhsDate > rhsDate
             }
 
         case .duration:
-            sorted = episodes.sorted { (lhs, rhs) in
+            return episodes.sorted { (lhs, rhs) in
                 guard let lhsDuration = lhs.duration else { return false }
                 guard let rhsDuration = rhs.duration else { return true }
-                return lhsDuration < rhsDuration
+                return ascending ? lhsDuration < rhsDuration : lhsDuration > rhsDuration
             }
 
         case .title:
             // localizedStandardCompare provides Finder-style natural sort ("Episode 2" before "Episode 10")
-            sorted = episodes.sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+            return episodes.sorted {
+                let result = $0.title.localizedStandardCompare($1.title)
+                return ascending ? result == .orderedAscending : result == .orderedDescending
+            }
 
         case .playStatus:
-            sorted = episodes.sorted { playStatusValue($0) < playStatusValue($1) }
+            return episodes.sorted {
+                let lv = playStatusValue($0), rv = playStatusValue($1)
+                return ascending ? lv < rv : lv > rv
+            }
 
         case .downloadStatus:
-            sorted = episodes.sorted { downloadStatusValue($0.downloadStatus) < downloadStatusValue($1.downloadStatus) }
+            return episodes.sorted {
+                let lv = downloadStatusValue($0.downloadStatus), rv = downloadStatusValue($1.downloadStatus)
+                return ascending ? lv < rv : lv > rv
+            }
 
         case .rating:
-            // ascending = lowest rating first; descending (default) = highest first
-            sorted = episodes.sorted { ($0.rating ?? 0) < ($1.rating ?? 0) }
+            // nil rating treated as 0 (unrated = lowest) in both directions
+            return episodes.sorted {
+                let lr = $0.rating ?? 0, rr = $1.rating ?? 0
+                return ascending ? lr < rr : lr > rr
+            }
 
         case .dateAdded:
-            // ascending = oldest added first; descending (default) = newest added first
-            sorted = episodes.sorted { $0.dateAdded < $1.dateAdded }
+            return episodes.sorted {
+                ascending ? $0.dateAdded < $1.dateAdded : $0.dateAdded > $1.dateAdded
+            }
         }
-        return ascending ? sorted : sorted.reversed()
     }
     
     // MARK: - Private Helpers

--- a/Packages/CoreModels/Sources/CoreModels/EpisodeSortService.swift
+++ b/Packages/CoreModels/Sources/CoreModels/EpisodeSortService.swift
@@ -8,58 +8,51 @@ public struct EpisodeSortService: Sendable {
     
     public init() {}
     
-    /// Sort episodes by criteria
+    /// Sort episodes by criteria using the sort type's default direction.
     public func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy) -> [Episode] {
+        return sortEpisodes(episodes, by: sortBy, ascending: sortBy.defaultAscending)
+    }
+
+    /// Sort episodes by criteria with an explicit direction.
+    /// Each case sorts in canonical ascending order; `ascending: false` reverses the result.
+    /// Nil pubDate/duration values are pushed to the end regardless of direction.
+    public func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy, ascending: Bool) -> [Episode] {
+        let sorted: [Episode]
         switch sortBy {
-        case .pubDateNewest:
-            return episodes.sorted { (lhs, rhs) in
-                guard let lhsDate = lhs.pubDate else { return false }
+        case .pubDateNewest, .pubDateOldest:
+            // Both cases sort on pubDate; ascending = oldest first, descending = newest first.
+            sorted = episodes.sorted { (lhs, rhs) in
+                guard let lhsDate = lhs.pubDate else { return false } // nil = pushed to end in ascending
                 guard let rhsDate = rhs.pubDate else { return true }
-                return lhsDate > rhsDate
-            }
-            
-        case .pubDateOldest:
-            return episodes.sorted { (lhs, rhs) in
-                guard let lhsDate = lhs.pubDate else { return true }
-                guard let rhsDate = rhs.pubDate else { return false }
                 return lhsDate < rhsDate
             }
-            
+
         case .duration:
-            return episodes.sorted { (lhs, rhs) in
+            sorted = episodes.sorted { (lhs, rhs) in
                 guard let lhsDuration = lhs.duration else { return false }
                 guard let rhsDuration = rhs.duration else { return true }
                 return lhsDuration < rhsDuration
             }
-            
+
         case .title:
-            return episodes.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
-            
+            // localizedStandardCompare provides Finder-style natural sort ("Episode 2" before "Episode 10")
+            sorted = episodes.sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+
         case .playStatus:
-            return episodes.sorted { (lhs, rhs) in
-                // Order: unplayed, in-progress, played
-                let lhsStatus = playStatusValue(lhs)
-                let rhsStatus = playStatusValue(rhs)
-                return lhsStatus < rhsStatus
-            }
-            
+            sorted = episodes.sorted { playStatusValue($0) < playStatusValue($1) }
+
         case .downloadStatus:
-            return episodes.sorted { (lhs, rhs) in
-                let lhsValue = downloadStatusValue(lhs.downloadStatus)
-                let rhsValue = downloadStatusValue(rhs.downloadStatus)
-                return lhsValue < rhsValue
-            }
-            
+            sorted = episodes.sorted { downloadStatusValue($0.downloadStatus) < downloadStatusValue($1.downloadStatus) }
+
         case .rating:
-            return episodes.sorted { (lhs, rhs) in
-                let lhsRating = lhs.rating ?? 0
-                let rhsRating = rhs.rating ?? 0
-                return lhsRating > rhsRating // Higher ratings first
-            }
-            
+            // ascending = lowest rating first; descending (default) = highest first
+            sorted = episodes.sorted { ($0.rating ?? 0) < ($1.rating ?? 0) }
+
         case .dateAdded:
-            return episodes.sorted { $0.dateAdded > $1.dateAdded }
+            // ascending = oldest added first; descending (default) = newest added first
+            sorted = episodes.sorted { $0.dateAdded < $1.dateAdded }
         }
+        return ascending ? sorted : sorted.reversed()
     }
     
     // MARK: - Private Helpers

--- a/Packages/CoreModels/Tests/CoreModelsTests/EpisodeFilteringTests.swift
+++ b/Packages/CoreModels/Tests/CoreModelsTests/EpisodeFilteringTests.swift
@@ -132,12 +132,12 @@ final class EpisodeFilteringTests: XCTestCase {
         // When: Sorting by title
         let sortedEpisodes = filterService.sortEpisodes(testEpisodes, by: .title)
         
-        // Then: Should be sorted alphabetically
+        // Then: Should be sorted using natural (Finder-style) sort order
         for i in 0..<sortedEpisodes.count-1 {
             let currentTitle = sortedEpisodes[i].title
             let nextTitle = sortedEpisodes[i+1].title
-            XCTAssertTrue(currentTitle.localizedCaseInsensitiveCompare(nextTitle) != .orderedDescending, 
-                         "Episodes should be sorted alphabetically by title")
+            XCTAssertTrue(currentTitle.localizedStandardCompare(nextTitle) != .orderedDescending,
+                         "Episodes should be sorted by title using natural sort order")
         }
     }
     

--- a/Packages/CoreModels/Tests/CoreModelsTests/EpisodeSortServiceTests.swift
+++ b/Packages/CoreModels/Tests/CoreModelsTests/EpisodeSortServiceTests.swift
@@ -127,10 +127,171 @@ final class EpisodeSortServiceTests: XCTestCase {
     func testSortByDateAdded() async {
         // When: Sorting by date added
         let sorted = sortService.sortEpisodes(testEpisodes, by: .dateAdded)
-        
+
         // Then: Episodes should be ordered newest to oldest added
         XCTAssertEqual(sorted[0].id, "ep3", "Most recently added should be first")
         XCTAssertEqual(sorted[1].id, "ep2", "Second added should be second")
         XCTAssertEqual(sorted[2].id, "ep1", "First added should be last")
+    }
+
+    // MARK: - Direction Override Tests
+
+    func testSortByTitleAscending() async {
+        // Given: Sort by title with ascending = true (A→Z)
+        let sorted = sortService.sortEpisodes(testEpisodes, by: .title, ascending: true)
+
+        // Then: Alphabetical A→Z
+        XCTAssertEqual(sorted[0].id, "ep1", "Episode Alpha should be first")
+        XCTAssertEqual(sorted[1].id, "ep2", "Episode Beta should be second")
+        XCTAssertEqual(sorted[2].id, "ep3", "Episode Charlie should be last")
+    }
+
+    func testSortByTitleDescending() async {
+        // Given: Sort by title with ascending = false (Z→A)
+        let sorted = sortService.sortEpisodes(testEpisodes, by: .title, ascending: false)
+
+        // Then: Reverse alphabetical Z→A
+        XCTAssertEqual(sorted[0].id, "ep3", "Episode Charlie should be first")
+        XCTAssertEqual(sorted[1].id, "ep2", "Episode Beta should be second")
+        XCTAssertEqual(sorted[2].id, "ep1", "Episode Alpha should be last")
+    }
+
+    func testNaturalSortTitleAscending() async {
+        // Given: Episodes with numeric titles that differ between lexicographic and natural sort
+        let calendar = Calendar.current
+        let now = Date()
+        let numericEpisodes = [
+            Episode(
+                id: "e10", title: "Episode 10", podcastID: "p1",
+                playbackPosition: 0, isPlayed: false,
+                pubDate: calendar.date(byAdding: .day, value: -1, to: now),
+                audioURL: nil,
+                dateAdded: calendar.date(byAdding: .day, value: -1, to: now)!
+            ),
+            Episode(
+                id: "e2", title: "Episode 2", podcastID: "p1",
+                playbackPosition: 0, isPlayed: false,
+                pubDate: calendar.date(byAdding: .day, value: -2, to: now),
+                audioURL: nil,
+                dateAdded: calendar.date(byAdding: .day, value: -2, to: now)!
+            ),
+            Episode(
+                id: "e11", title: "Episode 11", podcastID: "p1",
+                playbackPosition: 0, isPlayed: false,
+                pubDate: calendar.date(byAdding: .day, value: -3, to: now),
+                audioURL: nil,
+                dateAdded: calendar.date(byAdding: .day, value: -3, to: now)!
+            ),
+            Episode(
+                id: "e1", title: "Episode 1", podcastID: "p1",
+                playbackPosition: 0, isPlayed: false,
+                pubDate: calendar.date(byAdding: .day, value: -4, to: now),
+                audioURL: nil,
+                dateAdded: calendar.date(byAdding: .day, value: -4, to: now)!
+            )
+        ]
+
+        // When: Sort ascending with natural sort
+        let sorted = sortService.sortEpisodes(numericEpisodes, by: .title, ascending: true)
+
+        // Then: Natural numeric order (1, 2, 10, 11), not lexicographic (1, 10, 11, 2)
+        XCTAssertEqual(sorted[0].id, "e1",  "Episode 1 should be first")
+        XCTAssertEqual(sorted[1].id, "e2",  "Episode 2 should be second")
+        XCTAssertEqual(sorted[2].id, "e10", "Episode 10 should be third")
+        XCTAssertEqual(sorted[3].id, "e11", "Episode 11 should be fourth")
+    }
+
+    func testNaturalSortTitleDescending() async {
+        // Given: Same numeric episodes as above
+        let calendar = Calendar.current
+        let now = Date()
+        let numericEpisodes = [
+            Episode(id: "e10", title: "Episode 10", podcastID: "p1", playbackPosition: 0, isPlayed: false,
+                    pubDate: nil, audioURL: nil, dateAdded: now),
+            Episode(id: "e2",  title: "Episode 2",  podcastID: "p1", playbackPosition: 0, isPlayed: false,
+                    pubDate: nil, audioURL: nil, dateAdded: calendar.date(byAdding: .second, value: -1, to: now)!),
+            Episode(id: "e11", title: "Episode 11", podcastID: "p1", playbackPosition: 0, isPlayed: false,
+                    pubDate: nil, audioURL: nil, dateAdded: calendar.date(byAdding: .second, value: -2, to: now)!),
+            Episode(id: "e1",  title: "Episode 1",  podcastID: "p1", playbackPosition: 0, isPlayed: false,
+                    pubDate: nil, audioURL: nil, dateAdded: calendar.date(byAdding: .second, value: -3, to: now)!)
+        ]
+
+        // When: Sort descending
+        let sorted = sortService.sortEpisodes(numericEpisodes, by: .title, ascending: false)
+
+        // Then: Reverse natural order (11, 10, 2, 1)
+        XCTAssertEqual(sorted[0].id, "e11", "Episode 11 should be first")
+        XCTAssertEqual(sorted[1].id, "e10", "Episode 10 should be second")
+        XCTAssertEqual(sorted[2].id, "e2",  "Episode 2 should be third")
+        XCTAssertEqual(sorted[3].id, "e1",  "Episode 1 should be fourth")
+    }
+
+    func testSortByDurationAscending() async {
+        // Given: Sort by duration ascending (shortest first — also the default)
+        let sorted = sortService.sortEpisodes(testEpisodes, by: .duration, ascending: true)
+
+        XCTAssertEqual(sorted[0].id, "ep1", "Shortest (30 min) should be first")
+        XCTAssertEqual(sorted[2].id, "ep3", "Longest (60 min) should be last")
+    }
+
+    func testSortByDurationDescending() async {
+        // Given: Sort by duration descending (longest first)
+        let sorted = sortService.sortEpisodes(testEpisodes, by: .duration, ascending: false)
+
+        XCTAssertEqual(sorted[0].id, "ep3", "Longest (60 min) should be first")
+        XCTAssertEqual(sorted[2].id, "ep1", "Shortest (30 min) should be last")
+    }
+
+    func testSortByRatingDescending() async {
+        // Given: Sort by rating descending (highest first — also the default)
+        let sorted = sortService.sortEpisodes(testEpisodes, by: .rating, ascending: false)
+
+        // Then: ep3 has rating 5, others have nil (0)
+        XCTAssertEqual(sorted[0].id, "ep3", "Highest rated should be first")
+    }
+
+    func testSortByRatingAscending() async {
+        // Given: Sort by rating ascending (lowest first)
+        let sorted = sortService.sortEpisodes(testEpisodes, by: .rating, ascending: true)
+
+        // Then: ep3 (rating 5) should be last; unrated (0) episodes are first
+        XCTAssertEqual(sorted[2].id, "ep3", "Highest rated should be last when ascending")
+    }
+
+    func testDefaultAscendingNilFallback() async {
+        // Given: Sort using the convenience overload (no ascending param) matches the default direction.
+        // For .title, defaultAscending is true (A→Z).
+        let sortedConvenience = sortService.sortEpisodes(testEpisodes, by: .title)
+        let sortedExplicit = sortService.sortEpisodes(testEpisodes, by: .title, ascending: true)
+
+        // Then: Both should produce identical ordering
+        XCTAssertEqual(sortedConvenience.map { $0.id }, sortedExplicit.map { $0.id },
+                       "Convenience overload should match explicit ascending=true for .title")
+    }
+
+    func testCodableRoundTripWithAscending() throws {
+        // Given: An EpisodeFilter with sortAscending explicitly set
+        let filter = EpisodeFilter(sortBy: .title, sortAscending: true)
+
+        // When: Encode then decode
+        let encoded = try JSONEncoder().encode(filter)
+        let decoded = try JSONDecoder().decode(EpisodeFilter.self, from: encoded)
+
+        // Then: Round-trip preserves sortAscending
+        XCTAssertEqual(decoded.sortAscending, true, "sortAscending: true should survive encode/decode")
+        XCTAssertEqual(decoded.sortBy, .title)
+    }
+
+    func testCodableBackwardCompatNilAscending() throws {
+        // Given: JSON without a sortAscending key (pre-feature persisted data)
+        let json = #"{"conditions":[],"logic":"and","sortBy":"title"}"#
+        let data = Data(json.utf8)
+
+        // When: Decode
+        let filter = try JSONDecoder().decode(EpisodeFilter.self, from: data)
+
+        // Then: sortAscending is nil → effectiveAscending falls back to defaultAscending for .title (true)
+        XCTAssertNil(filter.sortAscending, "Missing key should decode as nil")
+        XCTAssertTrue(filter.effectiveAscending, "effectiveAscending should fall back to title's default (ascending)")
     }
 }

--- a/Packages/CoreModels/Tests/CoreModelsTests/EpisodeSortServiceTests.swift
+++ b/Packages/CoreModels/Tests/CoreModelsTests/EpisodeSortServiceTests.swift
@@ -195,8 +195,8 @@ final class EpisodeSortServiceTests: XCTestCase {
         let sorted = sortService.sortEpisodes(numericEpisodes, by: .title, ascending: true)
 
         // Then: Natural numeric order (1, 2, 10, 11), not lexicographic (1, 10, 11, 2)
-        XCTAssertEqual(sorted[0].id, "e1",  "Episode 1 should be first")
-        XCTAssertEqual(sorted[1].id, "e2",  "Episode 2 should be second")
+        XCTAssertEqual(sorted[0].id, "e1", "Episode 1 should be first")
+        XCTAssertEqual(sorted[1].id, "e2", "Episode 2 should be second")
         XCTAssertEqual(sorted[2].id, "e10", "Episode 10 should be third")
         XCTAssertEqual(sorted[3].id, "e11", "Episode 11 should be fourth")
     }
@@ -208,11 +208,11 @@ final class EpisodeSortServiceTests: XCTestCase {
         let numericEpisodes = [
             Episode(id: "e10", title: "Episode 10", podcastID: "p1", playbackPosition: 0, isPlayed: false,
                     pubDate: nil, audioURL: nil, dateAdded: now),
-            Episode(id: "e2",  title: "Episode 2",  podcastID: "p1", playbackPosition: 0, isPlayed: false,
+            Episode(id: "e2", title: "Episode 2", podcastID: "p1", playbackPosition: 0, isPlayed: false,
                     pubDate: nil, audioURL: nil, dateAdded: calendar.date(byAdding: .second, value: -1, to: now)!),
             Episode(id: "e11", title: "Episode 11", podcastID: "p1", playbackPosition: 0, isPlayed: false,
                     pubDate: nil, audioURL: nil, dateAdded: calendar.date(byAdding: .second, value: -2, to: now)!),
-            Episode(id: "e1",  title: "Episode 1",  podcastID: "p1", playbackPosition: 0, isPlayed: false,
+            Episode(id: "e1", title: "Episode 1", podcastID: "p1", playbackPosition: 0, isPlayed: false,
                     pubDate: nil, audioURL: nil, dateAdded: calendar.date(byAdding: .second, value: -3, to: now)!)
         ]
 
@@ -222,8 +222,8 @@ final class EpisodeSortServiceTests: XCTestCase {
         // Then: Reverse natural order (11, 10, 2, 1)
         XCTAssertEqual(sorted[0].id, "e11", "Episode 11 should be first")
         XCTAssertEqual(sorted[1].id, "e10", "Episode 10 should be second")
-        XCTAssertEqual(sorted[2].id, "e2",  "Episode 2 should be third")
-        XCTAssertEqual(sorted[3].id, "e1",  "Episode 1 should be fourth")
+        XCTAssertEqual(sorted[2].id, "e2", "Episode 2 should be third")
+        XCTAssertEqual(sorted[3].id, "e1", "Episode 1 should be fourth")
     }
 
     func testSortByDurationAscending() async {

--- a/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeFilterViews.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeFilterViews.swift
@@ -41,31 +41,46 @@ public struct EpisodeFilterButton: View {
 
 // MARK: - Sort Picker
 
-/// Picker for selecting episode sort order
+/// Picker for selecting episode sort order with a direction toggle.
 public struct EpisodeSortPicker: View {
     @Binding var selectedSort: EpisodeSortBy
-    
-    public init(selectedSort: Binding<EpisodeSortBy>) {
+    @Binding var ascending: Bool
+
+    public init(selectedSort: Binding<EpisodeSortBy>, ascending: Binding<Bool>) {
         self._selectedSort = selectedSort
+        self._ascending = ascending
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Sort By")
                 .font(.headline)
                 .foregroundStyle(.primary)
-            
-            Picker("Sort By", selection: $selectedSort) {
-                ForEach(EpisodeSortBy.allCases, id: \.self) { sortOption in
-                    HStack {
-                        Image(systemName: sortOption.systemImage)
-                        Text(sortOption.displayName)
+
+            HStack(spacing: 12) {
+                Picker("Sort By", selection: $selectedSort) {
+                    ForEach(EpisodeSortBy.allCases, id: \.self) { sortOption in
+                        HStack {
+                            Image(systemName: sortOption.systemImage)
+                            Text(sortOption.displayName)
+                        }
+                        .tag(sortOption)
                     }
-                    .tag(sortOption)
                 }
+                .pickerStyle(.menu)
+                .accessibilityIdentifier("Episode Sort Picker")
+
+                Button {
+                    ascending.toggle()
+                } label: {
+                    Image(systemName: ascending ? "chevron.up" : "chevron.down")
+                        .font(.body)
+                        .frame(minWidth: 44, minHeight: 44)
+                }
+                .accessibilityIdentifier("Sort Direction Toggle")
+                .accessibilityLabel(ascending ? "Sort ascending" : "Sort descending")
+                .foregroundStyle(.blue)
             }
-            .pickerStyle(.menu)
-            .accessibilityIdentifier("Episode Sort Picker")
         }
     }
 }
@@ -250,12 +265,13 @@ public struct ActiveFilterChip: View {
 public struct EpisodeFilterSheet: View {
     @State private var selectedCriteria: [EpisodeFilterCriteria]
     @State private var selectedSort: EpisodeSortBy
+    @State private var sortAscending: Bool
     @State private var filterLogic: FilterLogic
-    
+
     let initialFilter: EpisodeFilter
     let onApply: (EpisodeFilter) -> Void
     let onDismiss: () -> Void
-    
+
     public init(
         initialFilter: EpisodeFilter,
         onApply: @escaping (EpisodeFilter) -> Void,
@@ -264,27 +280,32 @@ public struct EpisodeFilterSheet: View {
         self.initialFilter = initialFilter
         self.onApply = onApply
         self.onDismiss = onDismiss
-        
+
         self._selectedCriteria = State(initialValue: initialFilter.conditions.map { $0.criteria })
         self._selectedSort = State(initialValue: initialFilter.sortBy)
+        self._sortAscending = State(initialValue: initialFilter.effectiveAscending)
         self._filterLogic = State(initialValue: initialFilter.logic)
     }
-    
+
     public var body: some View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 24) {
-                    EpisodeSortPicker(selectedSort: $selectedSort)
-                    
+                    EpisodeSortPicker(selectedSort: $selectedSort, ascending: $sortAscending)
+                        .onChange(of: selectedSort) { _, newSort in
+                            // Reset direction to the new sort type's default when sort type changes.
+                            sortAscending = newSort.defaultAscending
+                        }
+
                     Divider()
-                    
+
                     EpisodeFilterCriteriaGrid(selectedCriteria: $selectedCriteria)
-                    
+
                     if selectedCriteria.count > 1 {
                         Divider()
                         filterLogicPicker
                     }
-                    
+
                     Spacer(minLength: 20)
                 }
                 .padding()
@@ -296,14 +317,15 @@ public struct EpisodeFilterSheet: View {
                     Button("Cancel", action: onDismiss)
                         .accessibilityIdentifier("Cancel Filter")
                 }
-                
+
                 ToolbarItem(placement: PlatformToolbarPlacement.primaryAction) {
                     Button("Apply") {
                         let conditions = selectedCriteria.map { EpisodeFilterCondition(criteria: $0) }
                         let filter = EpisodeFilter(
                             conditions: conditions,
                             logic: filterLogic,
-                            sortBy: selectedSort
+                            sortBy: selectedSort,
+                            sortAscending: sortAscending
                         )
                         onApply(filter)
                     }

--- a/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeFilterViews.swift
+++ b/Packages/LibraryFeature/Sources/LibraryFeature/EpisodeFilterViews.swift
@@ -321,11 +321,14 @@ public struct EpisodeFilterSheet: View {
                 ToolbarItem(placement: PlatformToolbarPlacement.primaryAction) {
                     Button("Apply") {
                         let conditions = selectedCriteria.map { EpisodeFilterCondition(criteria: $0) }
+                        // Only persist an explicit direction when the user deviates from the default;
+                        // nil preserves "use default" semantics for legacy/unchanged filters.
+                        let explicitAscending: Bool? = sortAscending == selectedSort.defaultAscending ? nil : sortAscending
                         let filter = EpisodeFilter(
                             conditions: conditions,
                             logic: filterLogic,
                             sortBy: selectedSort,
-                            sortAscending: sortAscending
+                            sortAscending: explicitAscending
                         )
                         onApply(filter)
                     }

--- a/Packages/LibraryFeature/Tests/LibraryFeatureTests/EpisodeFilteringTests.swift
+++ b/Packages/LibraryFeature/Tests/LibraryFeatureTests/EpisodeFilteringTests.swift
@@ -646,6 +646,11 @@ final class MockEpisodeFilterService: EpisodeFilterService, @unchecked Sendable 
     return episodes  // Return unchanged for testing
   }
 
+  func sortEpisodes(_ episodes: [Episode], by sortBy: EpisodeSortBy, ascending: Bool) -> [Episode] {
+    sortEpisodesCalled = true
+    return episodes  // Return unchanged for testing
+  }
+
   func searchEpisodes(_ episodes: [Episode], query: String, filter: EpisodeFilter? = nil)
     -> [Episode]
   {

--- a/zpodUITests/UITestHelpers.swift
+++ b/zpodUITests/UITestHelpers.swift
@@ -635,7 +635,11 @@ extension XCTestCase {
     return anyMatch.exists ? anyMatch : nil
   }
 
-  /// Wait for loading completion using predicate-based waiting (no async dispatching)
+  /// Wait for loading completion using direct polling (quiescence-independent).
+  ///
+  /// Uses a polling loop rather than `XCTNSPredicateExpectation` so that ongoing
+  /// async Tasks in the app (e.g. `PlaybackStateCoordinator` state emissions) do not
+  /// prevent the check from completing while the app is non-quiescent.
   @MainActor
   func waitForLoadingToComplete(
     in app: XCUIApplication,
@@ -650,10 +654,9 @@ extension XCTestCase {
       "Podcast List Container",
     ]
 
-    // Use predicate for synchronous polling (avoids DispatchQueue.main deadlocks)
-    let predicate = NSPredicate { [weak self] _, _ in
-      guard let self else { return false }
+    let deadline = Date().addingTimeInterval(timeout)
 
+    func checkLoaded() -> Bool {
       // Presence of the batch operations overlay indicates the view finished loading
       if app.otherElements.matching(identifier: "Batch Operation Progress").firstMatch.exists {
         return true
@@ -661,7 +664,7 @@ extension XCTestCase {
 
       // Check if any common container appears
       for containerIdentifier in commonContainers {
-        if let container = self.findContainerElement(in: app, identifier: containerIdentifier),
+        if let container = findContainerElement(in: app, identifier: containerIdentifier),
           container.exists
         {
           return true
@@ -669,7 +672,8 @@ extension XCTestCase {
       }
 
       // Fallback: check if main navigation elements are present
-      let libraryTab = app.tabBars.matching(identifier: "Main Tab Bar").firstMatch.buttons.matching(identifier: "Library").firstMatch
+      let libraryTab = app.tabBars.matching(identifier: "Main Tab Bar").firstMatch
+        .buttons.matching(identifier: "Library").firstMatch
       let navigationBar = app.navigationBars.firstMatch
       let swiftPodcast = app.buttons.matching(identifier: "Podcast-swift-talk").firstMatch
 
@@ -683,15 +687,19 @@ extension XCTestCase {
       return false
     }
 
-    let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
-    expectation.expectationDescription = "App loading completes"
+    // Fast path: already loaded
+    if checkLoaded() { return true }
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
-    if result != .completed && ProcessInfo.processInfo.environment["CI"] != nil {
-      // Note: Commented out app.debugDescription as it can cause "Lost connection" errors when app crashes
+    // Poll until timeout
+    while Date() < deadline {
+      RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.1))
+      if checkLoaded() { return true }
+    }
+
+    if ProcessInfo.processInfo.environment["CI"] != nil {
       launchLogger.warning("Loading did not complete within \(timeout, privacy: .public)s.")
     }
-    return result == .completed
+    return false
   }
 }
 

--- a/zpodUITests/UITestHelpers.swift
+++ b/zpodUITests/UITestHelpers.swift
@@ -692,7 +692,7 @@ extension XCTestCase {
 
     // Poll until timeout
     while Date() < deadline {
-      RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.1))
+      RunLoop.current.run(until: Date().addingTimeInterval(0.1))
       if checkLoaded() { return true }
     }
 


### PR DESCRIPTION
## Summary

Closes #471 — implements **Scenario 1** (Sort Direction Toggle) and **Scenario 5** (Natural Title Sort) from `spec/06.3-extended-sorting.md`.

- Adds `sortAscending: Bool?` to `EpisodeFilter` with per-sort-type defaults (e.g. newest-first for dates, A→Z for titles)
- New `EpisodeSortService.sortEpisodes(_:by:ascending:)` overload respects explicit direction; existing single-param API unchanged
- Switches `.title` sort to `localizedStandardCompare` for natural numeric ordering ("Episode 2" before "Episode 10")
- UI: chevron toggle button in `EpisodeSortPicker` with accessible label; direction auto-resets when sort type changes
- Backward-compatible `Codable`: missing `sortAscending` key decodes as `nil` → falls back to default direction

## Files Changed (8)

| File | Change |
|------|--------|
| `CoreModels/EpisodeFiltering.swift` | `sortAscending: Bool?`, `effectiveAscending`, `defaultAscending` per sort type |
| `CoreModels/EpisodeSortService.swift` | New `ascending:` overload, natural title sort |
| `CoreModels/EpisodeFilterService.swift` | Protocol + impl pass `effectiveAscending` through |
| `CoreModels/EpisodeSearchHelper.swift` | Pass ascending to sort call |
| `LibraryFeature/EpisodeFilterViews.swift` | Direction toggle button, state management |
| `CoreModelsTests/EpisodeSortServiceTests.swift` | 11 new tests (direction, natural sort, codable compat) |
| `CoreModelsTests/EpisodeFilteringTests.swift` | Updated title sort assertion |
| `zpodUITests/UITestHelpers.swift` | Polling-based wait to avoid quiescence deadlock |

## Test Plan

- [x] 11 new unit tests in `EpisodeSortServiceTests` covering ascending/descending per type, natural sort, and Codable backward compat
- [x] Syntax gate passes (`./scripts/run-xcode-tests.sh -s`)
- [ ] Full regression (`./scripts/run-xcode-tests.sh`)
- [ ] Manual: open filter sheet, toggle direction arrow, verify sort reverses
- [ ] Manual: verify "Episode 1, 2, 10, 11" title sort order

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)